### PR TITLE
Fix jobname removing second timestamp

### DIFF
--- a/src/renate/tuning/tuning.py
+++ b/src/renate/tuning/tuning.py
@@ -643,7 +643,6 @@ def _execute_tuning_job_remotely(
         accelerator=accelerator,
         devices=devices,
     )
-    job_name = f"{job_name}-{job_timestamp}"
     dependencies = list(renate.__path__ + [config_file])
     if requirements_file is not None:
         dependencies.append(requirements_file)


### PR DESCRIPTION
Currently the timestamp is appended automatically twice to the job name.
This is not only useless, but it reduces the number of characters that the user can use for the job name (SM limits it to 63)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
