### PR TITLE
`max_epochs` is passed directly to `execute_tuning_job`

### DIFF
--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -290,6 +290,7 @@ def _execute_experiment_job_locally(
             metric=metric,
             backend="local",
             updater=config_space["updater"],
+            max_epochs=config_space["max_epochs"],
             chunk_id=update_id,
             state_url=state_url,
             next_state_url=next_state_url,

--- a/src/renate/cli/run_experiment_with_scenario.py
+++ b/src/renate/cli/run_experiment_with_scenario.py
@@ -94,6 +94,12 @@ class ExperimentCLI:
 
         argument_group = parser.add_argument_group("Optional Parameters")
         argument_group.add_argument(
+            "--max_epochs",
+            type=int,
+            default=defaults.MAX_EPOCHS,
+            help=f"Number of epochs trained at most. Default: {defaults.MAX_EPOCHS}",
+        )
+        argument_group.add_argument(
             "--seed",
             type=int,
             default=defaults.SEED,


### PR DESCRIPTION
Due to an API change, `max_epochs` was passed differently. The experiment code was changed to take that in account .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
