### PR TITLE
Rename DMC to Repeated Distillation, add default config space and example

### DIFF
--- a/doc/examples/train_mlp_locally.rst
+++ b/doc/examples/train_mlp_locally.rst
@@ -55,5 +55,8 @@ still above 90% after processing the second one.
 After the execution is completed, it will be possible to inspect the two
 different folders containing the learner states.
 
+Another example using Repeated Distillation and HPO is available in the file called
+:code:`start_training_with_hpo.py`.
+
 
 

--- a/examples/train_mlp_locally/start_training_with_hpo.py
+++ b/examples/train_mlp_locally/start_training_with_hpo.py
@@ -1,0 +1,37 @@
+from renate.tuning import execute_tuning_job
+from renate.tuning.config_spaces import config_space
+
+if __name__ == "__main__":
+
+    # we run the first training job on the MNIST classes [0-4]
+    execute_tuning_job(
+        config_space=config_space("RD"),  # getting the default search space
+        mode="max",
+        metric="val_accuracy",
+        updater="RD",  # use the RepeatedDistillationModelUpdater
+        max_epochs=50,
+        chunk_id=0,  # this selects the first chunk of the dataset
+        config_file="renate_config.py",
+        next_state_url="./state_dump_first_model_rd/",  # this is where the model will be stored
+        backend="local",  # the training job will run on the local machine
+        scheduler="asha",
+        # using only 5 trials will not give great performance but this is just an example
+        max_num_trials_finished=5,
+    )
+
+    # retrieve the model from `./state_dump_first_model_rd/` if you want -- don't delete it
+
+    execute_tuning_job(
+        config_space=config_space("RD"),
+        mode="max",
+        metric="val_accuracy",
+        updater="RD",
+        max_epochs=50,
+        chunk_id=1,  # this time we use the second chunk of the dataset
+        config_file="renate_config.py",
+        state_url="./state_dump_first_model_rd/",  # the output of the first training job is loaded
+        next_state_url="./state_dump_second_model_rd/",  # the new model will be stored in this folder
+        backend="local",
+        scheduler="asha",
+        max_num_trials_finished=5,
+    )

--- a/examples/train_mlp_locally/start_training_without_hpo.py
+++ b/examples/train_mlp_locally/start_training_without_hpo.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-import renate
 from renate.tuning import execute_tuning_job
 
 

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from syne_tune.optimizer.scheduler import TrialScheduler
 
 from renate import defaults
-from renate.updaters.experimental.dmc import DeepModelConsolidationModelUpdater
+from renate.updaters.experimental.repeated_distill import RepeatedDistillationModelUpdater
 from renate.updaters.experimental.er import (
     CLSExperienceReplayModelUpdater,
     DarkExperienceReplayModelUpdater,
@@ -83,9 +83,9 @@ def get_updater_and_learner_kwargs(
     elif args.updater == "OfflineER":
         learner_args = learner_args + ["loss_weight_new_data", "memory_size", "memory_batch_size"]
         updater_class = OfflineExperienceReplayModelUpdater
-    elif args.updater == "DMC":
+    elif args.updater == "RD":
         learner_args = learner_args + ["memory_size"]
-        updater_class = DeepModelConsolidationModelUpdater
+        updater_class = RepeatedDistillationModelUpdater
     elif args.updater == "GDumb":
         learner_args = learner_args + ["memory_size"]
         updater_class = GDumbModelUpdater
@@ -422,8 +422,8 @@ def parse_super_experience_replay_arguments(parser: argparse.Namespace) -> None:
     _parse_base_experience_replay_arguments(parser)
 
 
-def parse_dmc_learner_arguments(parser: argparse.Namespace) -> None:
-    """A helper function that adds DMC Learner arguments."""
+def parse_rd_learner_arguments(parser: argparse.Namespace) -> None:
+    """A helper function that adds Repeated Distill Learner arguments."""
     parser.add_argument(
         "--memory_size",
         type=int,
@@ -494,6 +494,6 @@ parse_by_updater = {
     "Super-ER": parse_super_experience_replay_arguments,
     "GDumb": parse_gdumb_arguments,
     "Joint": parse_joint_arguments,
-    "DMC": parse_dmc_learner_arguments,
+    "RD": parse_rd_learner_arguments,
     "OfflineER": parse_replay_learner_arguments,
 }

--- a/src/renate/tuning/config_spaces.py
+++ b/src/renate/tuning/config_spaces.py
@@ -57,6 +57,16 @@ _super_er_config_space = {
     },
 }
 
+_repeated_distill_config_space = {
+    "optimizer": choice(["SGD", "Adam"]),
+    "momentum": loguniform(1e-6, 1e-1),
+    "weight_decay": loguniform(1e-6, 1e-2),
+    "learning_rate": loguniform(0.001, 0.5),
+    "batch_size": choice([32, 64, 128]),
+    "max_epochs": 50,
+    "memory_size": 1000,
+}
+
 
 def config_space(updater: str) -> Dict[str, Union[Domain, str, int, float]]:
     """Returns the default configuration space for the updater."""
@@ -64,5 +74,6 @@ def config_space(updater: str) -> Dict[str, Union[Domain, str, int, float]]:
         "ER": _er_config_space,
         "DER": _der_config_space,
         "SUPER-ER": _super_er_config_space,
+        "RD": _repeated_distill_config_space,
     }
     return config_spaces[updater.upper()]

--- a/src/renate/updaters/experimental/repeated_distill.py
+++ b/src/renate/updaters/experimental/repeated_distill.py
@@ -70,16 +70,14 @@ def extract_logits(
     return torch.cat(logits, dim=0)
 
 
-class DeepModelConsolidationModelUpdater(ModelUpdater):
-    """An adapted version of Deep Model Consolidation (DMC).
-
-    Deep Model Consolidation (DMC) was proposed in
+class RepeatedDistillationModelUpdater(ModelUpdater):
+    """Repeated Distillation (RD) is inspired by Deep Model Consolidation (DMC), which was proposed in
 
         TODO: Fix citation once we agreed on a format.
         Zhang, Junting, et al. "Class-incremental learning via deep model consolidation."
         Proceedings of the IEEE/CVF Winter Conference on Applications of Computer Vision. 2020.
 
-    The idea underlying DMC is the following: Given a new task/batch, a new model copy is trained
+    The idea underlying RD is the following: Given a new task/batch, a new model copy is trained
     from scratch on that data. Subsequently, this expert model is consolidated with the previous
     model state via knowledge distillation. The resulting consolidated model state is maintained,
     whereas the expert model is discarded.
@@ -136,7 +134,7 @@ class DeepModelConsolidationModelUpdater(ModelUpdater):
         }
         super().__init__(
             model=model,
-            learner_class=DeepModelConsolidationLearner,
+            learner_class=RepeatedDistillationLearner,
             learner_kwargs=learner_kwargs,
             current_state_folder=current_state_folder,
             next_state_folder=next_state_folder,
@@ -212,8 +210,8 @@ class DeepModelConsolidationModelUpdater(ModelUpdater):
         return self._learner.on_model_update_end(train_dataset, val_dataset, task_id)
 
 
-class DeepModelConsolidationLearner(ReplayLearner):
-    """A learner performing model consolidation."""
+class RepeatedDistillationLearner(ReplayLearner):
+    """A learner performing distillation."""
 
     def __init__(
         self,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,7 +26,7 @@ from renate.benchmark.models.vision_transformer import (
     VisionTransformerL32,
 )
 from renate.models.renate_module import RenateModule
-from renate.updaters.experimental.dmc import DeepModelConsolidationLearner
+from renate.updaters.experimental.repeated_distill import RepeatedDistillationLearner
 from renate.updaters.experimental.er import ExperienceReplayLearner
 from renate.updaters.experimental.gdumb import GDumbLearner
 from renate.updaters.experimental.joint import JointLearner
@@ -95,7 +95,7 @@ LEARNER_KWARGS = {
         "batch_size": 10,
         "seed": 3,
     },
-    DeepModelConsolidationLearner: {
+    RepeatedDistillationLearner: {
         "optimizer": "SGD",
         "learning_rate": 1.23,
         "momentum": 0.9,
@@ -144,7 +144,7 @@ LEARNER_HYPERPARAMETER_UPDATES = {
         "weight_decay": 0.01,
         "batch_size": 128,
     },
-    DeepModelConsolidationLearner: {
+    RepeatedDistillationLearner: {
         "optimizer": "Adam",
         "learning_rate": 2.0,
         "weight_decay": 0.01,

--- a/test/renate/data/test_data_module.py
+++ b/test/renate/data/test_data_module.py
@@ -65,7 +65,7 @@ def test_csv_data_module(tmpdir):
         ("FashionMNIST", 60000, 10000, (1, 28, 28)),
         ("CIFAR10", 50000, 10000, (3, 32, 32)),
         ("CIFAR100", 50000, 10000, (3, 32, 32)),
-    ]
+    ],
 )
 def test_torchvision_data_module(tmpdir, dataset_name, num_tr, num_te, x_shape):
     """Test downloading of Torchvision data."""

--- a/test/renate/updaters/experimental/test_repeated_distill.py
+++ b/test/renate/updaters/experimental/test_repeated_distill.py
@@ -5,8 +5,8 @@ import torch
 from torch.utils.data import ConcatDataset, TensorDataset
 
 from renate import defaults
-from renate.updaters.experimental.dmc import (
-    DeepModelConsolidationModelUpdater,
+from renate.updaters.experimental.repeated_distill import (
+    RepeatedDistillationModelUpdater,
     double_distillation_loss,
 )
 
@@ -29,7 +29,7 @@ def test_dmc_runs_end_to_end():
 
     val = ConcatDataset(data)
 
-    updater = DeepModelConsolidationModelUpdater(
+    updater = RepeatedDistillationModelUpdater(
         model=mlp,
         memory_size=300,
         batch_size=20,
@@ -46,7 +46,7 @@ def test_dmc_memory_size_after_update(memory_size, dataset_size):
     model = pytest.helpers.get_renate_module_mlp(
         num_inputs=10, num_outputs=3, hidden_size=20, num_hidden_layers=1
     )
-    model_updater = DeepModelConsolidationModelUpdater(
+    model_updater = RepeatedDistillationModelUpdater(
         model=model,
         memory_size=memory_size,
         max_epochs=1,
@@ -75,7 +75,7 @@ def test_dmc_model_updater(tmpdir, provide_folder):
         train_num_samples=10,
         test_num_samples=5,
     )
-    model_updater = DeepModelConsolidationModelUpdater(
+    model_updater = RepeatedDistillationModelUpdater(
         model,
         memory_size=50,
         max_epochs=1,
@@ -98,11 +98,11 @@ def test_continuation_of_training_with_dmc_model_updater(tmpdir):
         test_num_samples=5,
     )
     state_url = defaults.current_state_folder(tmpdir)
-    model_updater = DeepModelConsolidationModelUpdater(
+    model_updater = RepeatedDistillationModelUpdater(
         model, memory_size=50, max_epochs=1, next_state_folder=state_url
     )
     model = model_updater.update(train_dataset, task_id=defaults.TASK_ID)
-    model_updater = DeepModelConsolidationModelUpdater(
+    model_updater = RepeatedDistillationModelUpdater(
         model, memory_size=50, max_epochs=1, current_state_folder=state_url
     )
     model_updater.update(train_dataset, task_id=defaults.TASK_ID)

--- a/test/renate/updaters/test_model_updater.py
+++ b/test/renate/updaters/test_model_updater.py
@@ -8,7 +8,7 @@ from torchvision.transforms import Lambda
 
 from conftest import LEARNERS_USING_SIMPLE_UPDATER, LEARNER_KWARGS, check_learner_transforms
 from renate import defaults
-from renate.updaters.experimental.dmc import DeepModelConsolidationModelUpdater
+from renate.updaters.experimental.repeated_distill import RepeatedDistillationModelUpdater
 from renate.updaters.learner import ReplayLearner
 
 
@@ -52,7 +52,7 @@ def test_model_updater_with_early_stopping(
     max_epochs = 10
     with warnings.catch_warnings(record=True) as warning_init:
         if updater_type == "DMC":
-            model_updater = DeepModelConsolidationModelUpdater(
+            model_updater = RepeatedDistillationModelUpdater(
                 model=model,
                 memory_size=50,
                 max_epochs=max_epochs,


### PR DESCRIPTION
* Renamed DMC to Repeated Distillation
* Added default search space
* Added example with toy problem for RD


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
