### PR TITLE
Harmonize optimization options in default configs; add one for OfflineER

### DIFF
--- a/src/renate/tuning/config_spaces.py
+++ b/src/renate/tuning/config_spaces.py
@@ -59,9 +59,7 @@ _super_er_config_space = {
 _repeated_distill_config_space = _replay_config_space
 _offline_er_config_space = {
     **_replay_config_space,
-    **{
-        "loss_weight_new_data": choice([None, 0.5])
-    }
+    **{"loss_weight_new_data": choice([None, 0.25, 0.5, 0.75])},
 }
 
 


### PR DESCRIPTION
There were some seemingly arbitrary differences between the optimization hyperparams for different methods, so I am making a proposal to harmonize that.

I also added a default config space for OfflineER.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
