### PR TITLE
Downgrading sphinx-opengraph version after failure

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 docutils~=0.19
 sphinx-copybutton~=0.5.1
 sphinx-hoverxref~=1.3.0
-sphinxext-opengraph~=0.7.4
+sphinxext-opengraph~=0.7.3
 pydata-sphinx-theme~=0.12.0
 sphinx-autodoc-typehints~=1.19.5


### PR DESCRIPTION
Rolling back sphinx-opengraph upgrade after failure in doc build on RTD


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
