### PR TITLE
Add finetuning model updater

### DIFF
--- a/doc/getting_started/supported_algorithms.rst
+++ b/doc/getting_started/supported_algorithms.rst
@@ -33,3 +33,6 @@ using Renate (e.g., using :py:func:`renate.tuning.tuning.execute_tuning_job`; se
    * - ``"Joint"``
      - :py:class:`JointLearner <renate.updaters.experimental.joint.JointLearner>`
      - Retraining from scratch on all data seen so far. Used as an "upper bound" in experiments, inefficient for practical use.
+   * - ``"FineTuning"``
+     - :py:class:`Learner <renate.updaters.experimental.learner.Learner>`
+     - Fine-tuning the existing model using the new data without any sort of mitigation for forgetting. Users as "lower bound" baseline in the experiments.

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from syne_tune.optimizer.scheduler import TrialScheduler
 
 from renate import defaults
+from renate.updaters.experimental.fine_tuning import FineTuningModelUpdater
 from renate.updaters.experimental.repeated_distill import RepeatedDistillationModelUpdater
 from renate.updaters.experimental.er import (
     CLSExperienceReplayModelUpdater,
@@ -92,6 +93,9 @@ def get_updater_and_learner_kwargs(
     elif args.updater == "Joint":
         learner_args = learner_args
         updater_class = JointModelUpdater
+    elif args.updater == "FineTuning":
+        learner_args = learner_args
+        updater_class = FineTuningModelUpdater
     if updater_class is None:
         raise ValueError(f"Unknown learner {args.updater}.")
     learner_kwargs = {arg: value for arg, value in vars(args).items() if arg in learner_args}
@@ -248,6 +252,11 @@ def parse_gdumb_arguments(parser: argparse.Namespace) -> None:
 
 def parse_joint_arguments(parser: argparse.Namespace) -> None:
     """A helper function that adds Joint Learner arguments."""
+    pass
+
+
+def parse_finetuning_arguments(parser: argparse.Namespace) -> None:
+    """A helper function that adds Fine Tuning arguments."""
     pass
 
 
@@ -509,6 +518,7 @@ parse_by_updater = {
     "Super-ER": parse_super_experience_replay_arguments,
     "GDumb": parse_gdumb_arguments,
     "Joint": parse_joint_arguments,
+    "FineTuning": parse_finetuning_arguments,
     "RD": parse_rd_learner_arguments,
     "OfflineER": parse_replay_learner_arguments,
 }

--- a/src/renate/updaters/experimental/fine_tuning.py
+++ b/src/renate/updaters/experimental/fine_tuning.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Callable, Dict, Optional
+
+import torchmetrics
+from pytorch_lightning.loggers.logger import Logger
+
+from renate import defaults
+from renate.models import RenateModule
+from renate.updaters.learner import Learner
+from renate.updaters.model_updater import SimpleModelUpdater
+
+
+class FineTuningModelUpdater(SimpleModelUpdater):
+    def __init__(
+        self,
+        model: RenateModule,
+        optimizer: defaults.SUPPORTED_OPTIMIZERS_TYPE = defaults.OPTIMIZER,
+        learning_rate: float = defaults.LEARNING_RATE,
+        learning_rate_scheduler: defaults.SUPPORTED_LEARNING_RATE_SCHEDULERS_TYPE = defaults.LEARNING_RATE_SCHEDULER,  # noqa: E501
+        learning_rate_scheduler_gamma: float = defaults.LEARNING_RATE_SCHEDULER_GAMMA,
+        learning_rate_scheduler_step_size: int = defaults.LEARNING_RATE_SCHEDULER_STEP_SIZE,
+        momentum: float = defaults.MOMENTUM,
+        weight_decay: float = defaults.WEIGHT_DECAY,
+        batch_size: int = defaults.BATCH_SIZE,
+        current_state_folder: Optional[str] = None,
+        next_state_folder: Optional[str] = None,
+        max_epochs: int = defaults.MAX_EPOCHS,
+        train_transform: Optional[Callable] = None,
+        train_target_transform: Optional[Callable] = None,
+        test_transform: Optional[Callable] = None,
+        test_target_transform: Optional[Callable] = None,
+        metric: Optional[str] = None,
+        mode: defaults.SUPPORTED_TUNING_MODE_TYPE = "min",
+        logged_metrics: Optional[Dict[str, torchmetrics.Metric]] = None,
+        early_stopping_enabled: bool = False,
+        logger: Logger = defaults.LOGGER(**defaults.LOGGER_KWARGS),
+        accelerator: defaults.SUPPORTED_ACCELERATORS_TYPE = defaults.ACCELERATOR,
+        devices: Optional[int] = None,
+        seed: int = defaults.SEED,
+    ):
+        learner_kwargs = {
+            "optimizer": optimizer,
+            "learning_rate": learning_rate,
+            "learning_rate_scheduler": learning_rate_scheduler,
+            "learning_rate_scheduler_gamma": learning_rate_scheduler_gamma,
+            "learning_rate_scheduler_step_size": learning_rate_scheduler_step_size,
+            "momentum": momentum,
+            "weight_decay": weight_decay,
+            "batch_size": batch_size,
+            "seed": seed,
+        }
+        super().__init__(
+            model,
+            learner_class=Learner,
+            learner_kwargs=learner_kwargs,
+            current_state_folder=current_state_folder,
+            next_state_folder=next_state_folder,
+            max_epochs=max_epochs,
+            train_transform=train_transform,
+            train_target_transform=train_target_transform,
+            test_transform=test_transform,
+            test_target_transform=test_target_transform,
+            metric=metric,
+            mode=mode,
+            logged_metrics=logged_metrics,
+            early_stopping_enabled=early_stopping_enabled,
+            logger=logger,
+            accelerator=accelerator,
+            devices=devices,
+        )

--- a/test/renate/updaters/experimental/test_fine_tuning.py
+++ b/test/renate/updaters/experimental/test_fine_tuning.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import copy
+
+import pytest
+import torch
+
+import renate.defaults as defaults
+from renate.updaters.experimental.fine_tuning import FineTuningModelUpdater
+
+
+def get_model_and_dataset():
+    model = pytest.helpers.get_renate_module_mlp(
+        num_outputs=10, num_inputs=10, hidden_size=32, num_hidden_layers=3
+    )
+    dataset = torch.utils.data.TensorDataset(
+        torch.rand((100, 10)),
+        torch.randint(10, (100,)),
+    )
+    return model, dataset
+
+
+def test_fine_tuning_updater():
+    """This test checks that the memory buffer is updated correctly."""
+    init_model, dataset = get_model_and_dataset()
+
+    model = copy.deepcopy(init_model)
+
+    model_updater = FineTuningModelUpdater(model, max_epochs=1)
+    model_updater.update(train_dataset=dataset, task_id=defaults.TASK_ID)
+
+    for p1, p2 in zip(init_model.parameters(), model.parameters()):
+        assert p1.data.ne(p2.data).sum().item() != 0


### PR DESCRIPTION
Add a model updater doing fine-tuning.
This will simplify usage by providing an ad-hoc model updater for the fine-tuning baseline instead of requiring the usage of the SimpleModelUpdater in combination with Learner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
