### PR TITLE
Permutation Bug Fix

### DIFF
--- a/src/renate/benchmark/scenarios.py
+++ b/src/renate/benchmark/scenarios.py
@@ -238,6 +238,6 @@ class PermutationScenario(TransformScenario):
         transforms = [torch.nn.Identity()]
         for _ in range(num_tasks - 1):
             permutation = torch.randperm(input_dim, generator=rng)
-            transform = Lambda(lambda x: x.flatten()[permutation].view(x.size()))
+            transform = Lambda(lambda x, p=permutation: x.flatten()[p].view(x.size()))
             transforms.append(transform)
         super().__init__(data_module, transforms, chunk_id, seed)

--- a/src/renate/utils/pytorch.py
+++ b/src/renate/utils/pytorch.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import math
 from typing import List, Optional
 
 import torch
@@ -59,7 +60,7 @@ def _proportions_into_sizes(proportions: List[float], size: int) -> List[int]:
 
     In case of rounding doubts, any remaining samples are appended to the last split size.
     """
-    assert sum(proportions) == 1.0
+    assert math.isclose(sum(proportions), 1.0), sum(proportions)
     sizes = [round(proportion * size) for proportion in proportions[:-1]]
     sizes.append(size - sum(sizes))
     return sizes

--- a/test/renate/benchmark/test_scenarios.py
+++ b/test/renate/benchmark/test_scenarios.py
@@ -139,6 +139,31 @@ def test_permutation_scenario():
                 assert torch.equal(a, b)
 
 
+@pytest.mark.parametrize(
+    "scenario_class, scenario_kwargs",
+    (
+        (ImageRotationScenario, {"degrees": [0, 90, 180, 270]}),
+        (PermutationScenario, {"num_tasks": 4, "input_dim": (1, 5, 5)}),
+    ),
+)
+def test_transforms_in_transform_scenarios_are_distinct(scenario_class, scenario_kwargs):
+    """Tests if transformations are different.
+
+    Checks two cases: 1) transforms must not be same objects and 2) transforms must not perform identical operations.
+    """
+    data_module = DummyTorchVisionDataModule()
+    scenario = scenario_class(data_module=data_module, **scenario_kwargs, chunk_id=0, seed=0)
+    scenario.prepare_data()
+    scenario.setup()
+    x = data_module.X_train[0]
+    for i, transform in enumerate(scenario._transforms):
+        for j, transform2 in enumerate(scenario._transforms):
+            if i == j:
+                continue
+            assert transform != transform2
+            assert not torch.all(torch.isclose(transform(x), transform2(x)))
+
+
 def test_benchmark_scenario():
     data_module = DummyTorchVisionDataModuleWithChunks(num_chunks=3, val_size=0.2)
     for chunk_id in range(3):

--- a/test/renate/benchmark/test_scenarios.py
+++ b/test/renate/benchmark/test_scenarios.py
@@ -149,7 +149,8 @@ def test_permutation_scenario():
 def test_transforms_in_transform_scenarios_are_distinct(scenario_class, scenario_kwargs):
     """Tests if transformations are different.
 
-    Checks two cases: 1) transforms must not be same objects and 2) transforms must not perform identical operations.
+    Checks two cases: 1) transforms must not be same objects and 2) transforms must not perform
+    identical operations.
     """
     data_module = DummyTorchVisionDataModule()
     scenario = scenario_class(data_module=data_module, **scenario_kwargs, chunk_id=0, seed=0)


### PR DESCRIPTION
Permutation scenarios had a bug that cause all permutations but first to be the same.

Relaxing sum to 1 check to account for problems with precision.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
