### PR TITLE
Add link to benchmarking in getting started

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -2,6 +2,14 @@
 Getting Started
 ***************
 
+This section covers the usage of Renate from the installation to the training
+of a model. The content is intended to explain the basic steps to be taken when creating a new
+training pipeline based on Rente.
+
+If your goal is to test multiple Renate algorithms on your dataset or to test a specific algorithm on
+multiple datasets and scenarios, you will be better served by the benchmarking functionalities 
+provided in :doc:`../benchmarking/renate_benchmarks`.
+
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
Add link to benchmarking in getting started. The lack of visibility of the benchmarking functionalities were brought up my some of the customers testing the library (see https://github.com/awslabs/Renate/issues/130).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
