### PR TITLE
Custom Function Arguments Allow For More Types

### DIFF
--- a/.github/scripts/prepend_license.sh
+++ b/.github/scripts/prepend_license.sh
@@ -2,7 +2,7 @@
 
 exit_code=0
 
-for folder in "src" "test"
+for folder in "examples" "src" "test"
 do
 	for i in $(find $folder -name '*.py');
     do

--- a/doc/benchmarking/custom_benchmarks.rst
+++ b/doc/benchmarking/custom_benchmarks.rst
@@ -1,7 +1,7 @@
 Create Custom Benchmarks
 ************************
 
-There are several reasons to create a custom benchmark.
+There are several reasons to create a *custom* benchmark.
 For example, you want to use your own dataset, your own model, your own scenario or
 your own data splits.
 Creating a benchmark config file is very similar to creating the
@@ -9,9 +9,14 @@ Creating a benchmark config file is very similar to creating the
 It is not required to build it from scratch but can be build on top of
 :py:mod:`~renate.benchmark.experiment_config` in case you want to reuse parts of the
 Renate benchmarks.
-The main difference is that the object returned by the :code:`model_fn` needs to
-follow a slightly different interface.
 
+
+Your Own Function Arguments
+===========================
+Benchmarking still relies on the functions :code:`model_fn` and :code:`data_module_fn`. You can add further
+arguments as long as you use typing and data of type ``bool``, ``float``, ``int``, ``str``, ``list``, and ``tuple``.
+A more detailed explanation is provided in the
+:ref:`Renate config chapter <getting_started/how_to_renate_config:custom function arguments>`.
 
 Your Own Model
 ==============
@@ -35,12 +40,12 @@ with your data module as follows.
 .. code-block:: python
 
     def data_module_fn(
-        data_path: Union[Path, str], chunk_id: int, seed: int
+        data_path: Union[Path, str], chunk_id: int, seed: int, class_groupings: Tuple[Tuple[int]]
     ):
         data_module = CustomDataModule(data_path=data_path, seed=seed)
         return ClassIncrementalScenario(
             data_module=data_module,
-            class_groupings=[[0, 1], [2, 3]],
+            class_groupings=class_groupings,
             chunk_id=chunk_id,
         )
 
@@ -57,8 +62,9 @@ If you want to use a custom scenario, create your own class extending
 You will need to implement :py:meth:`~renate.benchmark.scenarios.Scenario.prepare_data()`
 such that it assigns the right subset of your data to :code:`self._train_data` and
 :code:`self._val_data` based on :code:`self._chunk_id`.
-By default, your model will be evaluated on the entire test data after each update step.
-If you want to change that, please override :py:meth:`~renate.benchmark.scenarios.Scenario.test_data()`
-as well.
-Please check the implementation of :py:class:`~renate.benchmark.scenarios.TransformScenario`
-for an example.
+Assign a list of datasets to :code:`self._test_data` where each entry of the list corresponds to one
+:code:`self._chunk_id`.
+At each update step, your model will be evaluated on the test datasets up to :code:`self._chunk_id`.
+You can modify this behavior to assign different values to :code:`self._test_data`.
+Please check the implementation of :py:class:`~renate.benchmark.scenarios.IIDScenario`
+for a simple example.

--- a/doc/benchmarking/renate_benchmarks.rst
+++ b/doc/benchmarking/renate_benchmarks.rst
@@ -141,7 +141,7 @@ Scenarios
 
 A scenario defines how the dataset is split into several data partitions.
 While running the benchmark, the model is trained sequentially on each data partition.
-The scenario can be selected by setting :code:`config_space["data_module_fn_scenario_name"]` accordingly.
+The scenario can be selected by setting :code:`config_space["scenario_name"]` accordingly.
 Each scenario might have specific settings which require additional changes of :code:`config_space`.
 We will describe those settings in the table below.
 
@@ -150,11 +150,8 @@ The first part contains all instances with classes 1 and 2, the second with clas
 
 .. code-block:: python
 
-    config_space["data_module_fn_scenario_name"] = "ClassIncrementalScenario"
-    config_space["data_module_fn_class_groupings"] = "[[1,2],[3,4]]"
-
-.. warning::
-    As already explained in more detail above, lists and tuples must be passed as strings without whitespaces.
+    config_space["scenario_name"] = "ClassIncrementalScenario"
+    config_space["class_groupings"] = ((1, 2), (3, 4))
 
 .. list-table:: Renate Scenario Overview
     :widths: 15 35 35
@@ -165,17 +162,38 @@ The first part contains all instances with classes 1 and 2, the second with clas
       - Settings
     * - :py:class:`~renate.benchmark.scenarios.BenchmarkScenario`
       - Used in combination only with CLEAR-10 or CLEAR-100.
-      - * :code:`data_module_fn_num_tasks`: Number of data partitions.
+      - * :code:`num_tasks`: Number of data partitions.
     * - :py:class:`~renate.benchmark.scenarios.ClassIncrementalScenario`
       - Creates data partitions by splitting the data according to class labels.
-      - * :code:`data_module_fn_class_groupings`: List of list containing the class labels.
-    * - :py:class:`~renate.benchmark.scenarios.PermutationScenario`
-      - Creates data partitions by randomly permuting the input features.
-      - * :code:`data_module_fn_num_tasks`: Number of data partitions.
-        * :code:`data_module_fn_input_dim`: Data dimensionality (tuple or int as string).
+      - * :code:`class_groupings`: Tuple of tuples containing the class labels, e.g., ``((1, ), (2, 3, 4))``.
+    * - :py:class:`~renate.benchmark.scenarios.FeatureSortingScenario`
+      - Splits data into different tasks after sorting the data according to a specific feature.
+        Can be used for image data as well. In that case channels are selected and we select according to
+        average channel value.
+        Random permutations may be applied to have a less strict sorting.
+      - * :code:`num_tasks`: Number of data partitions.
+        * :code:`feature_idx`: The feature index used for sorting.
+        * :code:`randomness`: After sorting, ``0.5 * N * randomness`` random pairs in the sequence are swapped where
+          ``N`` is the number of data points. This must be a value between 0 and 1. This allows for creating less strict
+          sorted scenarios.
+    * - :py:class:`~renate.benchmark.scenarios.HueShiftScenario`
+      - A specific scenario only for image data. Very similar to
+        :py:class:`~renate.benchmark.scenarios.FeatureSortingScenario` but this scenario sorts according to the hue
+        value of an image. Sorting can be less strict by applying random permutations.
+      - * :code:`num_tasks`: Number of data partitions.
+        * :code:`randomness`: After sorting, ``0.5 * N * randomness`` random pairs in the sequence are swapped where
+          ``N`` is the number of data points. This must be a value between 0 and 1. This allows for creating less strict
+          sorted scenarios.
+    * - :py:class:`~renate.benchmark.scenarios.IIDScenario`
+      - Divides the dataset uniformly at random into equally-sized partitions.
+      - * :code:`num_tasks`: Number of data partitions.
     * - :py:class:`~renate.benchmark.scenarios.ImageRotationScenario`
       - Creates data partitions by rotating the images by different angles.
-      - * :code:`data_module_fn_degrees`: Tuple of degrees as string.
+      - * :code:`degrees`: Tuple of degrees, e.g., ``(45, 90, 180)``.
+    * - :py:class:`~renate.benchmark.scenarios.PermutationScenario`
+      - Creates data partitions by randomly permuting the input features.
+      - * :code:`num_tasks`: Number of data partitions.
+        * :code:`input_dim`: Data dimensionality (tuple or int as string).
 
 Example: Class-incremental Learning on CIFAR-10
 ===============================================
@@ -189,3 +207,4 @@ Dark Experience Replay++ is used as the updating method with a memory buffer siz
 and the experiment is repeated 10 times.
 
 .. literalinclude:: ../../examples/benchmarking/class_incremental_learning_cifar10_der.py
+    :lines: 3-

--- a/doc/benchmarking/renate_benchmarks.rst
+++ b/doc/benchmarking/renate_benchmarks.rst
@@ -28,29 +28,20 @@ The benchmark will be configured by :code:`config_space`.
 Models
 ======
 
-You can select the model by assigning the corresponding name to :code:`config_space["model_fn_model_name"]`.
+You can select the model by assigning the corresponding name to :code:`config_space["model_name"]`.
 For example, to use a ResNet-18 model, you use
 
 .. code-block:: python
 
-    config_space["model_fn_model_name"] = "ResNet18"
+    config_space["model_name"] = "ResNet18"
 
-When using the model :py:class:`~renate.benchmark.models.mlp.MultiLayerPerceptron`,
-additional information needs to be provided.
-You need to define input and output size as well as depth and width of the network.
+Each model may have independent arguments.
+The ResNet-18 model requires to define the number of outputs.
 
 .. code-block:: python
 
-    config_space["model_fn_num_inputs"] = 32*32*3     # Number of inputs
-    config_space["model_fn_num_outputs"] = 10         # Number of outputs
-    config_space["model_fn_num_hidden_layers"] = 2    # Number of hidden layers
-    config_space["model_fn_hidden_size"] = "[16,16]"  # Hidden layer 1 and 2 have size 16
+    config_space["num_outputs"] = 10
 
-.. warning::
-    All additional arguments passed to :py:class:`~renate.benchmark.models.mlp.MultiLayerPerceptron` will be
-    converted to string and eventually converted back.
-    These strings must not contain any whitespaces. Since a Python lists or tuples automatically contain whitespaces,
-    they have to manually passed as strings without whitespaces.
 
 The full list of models and model names including a short description is provided in the following table.
 
@@ -59,32 +50,49 @@ The full list of models and model names including a short description is provide
 
     * - Model Name
       - Description
-    * - MultiLayerPerceptron
+      - Additional Inputs
+    * - `~renate.benchmark.models.mlp.MultiLayerPerceptron`
       - Neural network consisting of a sequence of dense layers.
-    * - ResNet18
+      - * ``num_inputs``: Input dimensionality of data.
+        * ``num_outputs``: Output dimensionality, for classification the number of classes.
+        * ``num_hidden_layers``: Number of hidden layers.
+        * ``hidden_size``: Size of hidden layers, can be ``int`` or ``Tuple[int]``.
+    * - `~renate.benchmark.models.resnet.ResNet18`
       - 18 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture
-    * - ResNet34
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.resnet.ResNet34`
       - 34 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture
-    * - ResNet50
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.resnet.ResNet50`
       - 50 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture
-    * - ResNet18CIFAR
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.resnet.ResNet18CIFAR`
       - 18 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture for small image sizes (approx 32x32)
-    * - ResNet34CIFAR
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.resnet.ResNet34CIFAR`
       - 34 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture for small image sizes (approx 32x32)
-    * - ResNet50CIFAR
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.resnet.ResNet50CIFAR`
       - 50 layer `ResNet <https://arxiv.org/abs/1512.03385>`_ CNN architecture for small image sizes (approx 32x32)
-    * - VisionTransformerCIFAR
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerCIFAR`
       - Base `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 32x32 with patch size 4.
-    * - VisionTransformerB16
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerB16`
       - Base `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 224x224 with patch size 16.
-    * - VisionTransformerB32
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerB32`
       - Base `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 224x224 with patch size 32.
-    * - VisionTransformerL16
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerL16`
       - Large `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 224x224 with patch size 16.
-    * - VisionTransformerL32
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerL32`
       - Large `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 224x224 with patch size 32.
-    * - VisionTransformerH14
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
+    * - `~renate.benchmark.models.vision_transformer.VisionTransformerH14`
       - Huge `Vision Transformer <https://arxiv.org/abs/2010.11929>`_ architecture for images of size 224x224 with patch size 14.
+      - * ``num_outputs``: Output dimensionality, for classification the number of classes.
 
 
 .. _benchmarking-renate-benchmarks-datasets:
@@ -92,16 +100,13 @@ The full list of models and model names including a short description is provide
 Datasets
 ========
 
-Similarly, you select the dataset by assigning the corresponding name to :code:`config_space["data_module_fn_dataset_name"]`.
-To use the matching preprocessing, the same value needs to be applied to :code:`config_space["transform_dataset_name"]`.
+Similarly, you select the dataset by assigning the corresponding name to :code:`config_space["dataset_name"]`.
 For example, to use the CIFAR-10 dataset with 10% of the data used for validation, you use
 
 .. code-block:: python
 
-    dataset_name = "CIFAR10"
-    config_space["data_module_fn_dataset_name"] = dataset_name
-    config_space["transform_dataset_name"] = dataset_name
-    config_space["data_module_fn_val_size"] = 0.1
+    config_space["dataset_name"] = "CIFAR10"
+    config_space["val_size"] = 0.1
 
 The following table contains the list of supported datasets.
 

--- a/doc/examples/train_classifier_sagemaker.rst
+++ b/doc/examples/train_classifier_sagemaker.rst
@@ -26,6 +26,7 @@ normalize and augment the dataset. More transformations can be added if needed,
 details on how to write a configuration file are available in :doc:`../getting_started/how_to_renate_config`.
 
 .. literalinclude:: ../../examples/simple_classifier_cifar10/renate_config.py
+    :lines: 3-
 
 Training
 ========
@@ -47,6 +48,7 @@ The description of the other arguments and a high level overview of how to run a
 training jobs are available in :doc:`../getting_started/how_to_run_training`.
 
 .. literalinclude:: ../../examples/simple_classifier_cifar10/start_with_hpo.py
+    :lines: 3-
 
 Once the training job terminates, the output will be available in the S3 bucket indicated
 in :code:`next_state_url`. For more information about how to interpret the output, see

--- a/doc/examples/train_mlp_locally.rst
+++ b/doc/examples/train_mlp_locally.rst
@@ -27,6 +27,7 @@ augmentation, and several other purposes. More details on how to write a
 configuration file are available in :doc:`../getting_started/how_to_renate_config`.
 
 .. literalinclude:: ../../examples/train_mlp_locally/renate_config.py
+    :lines: 3-
 
 Training
 ========
@@ -45,6 +46,7 @@ to the previously saved state using :code:`state_url`, as done in our example.
 More details about running training jobs are available in :doc:`../getting_started/how_to_run_training`.
 
 .. literalinclude:: ../../examples/train_mlp_locally/start_training_without_hpo.py
+    :lines: 3-
 
 Results
 =======

--- a/doc/getting_started/how_to_renate_config.rst
+++ b/doc/getting_started/how_to_renate_config.rst
@@ -29,7 +29,7 @@ method, which automatically handles model hyperparameters.
 
 .. literalinclude:: ../../examples/getting_started/renate_config.py
     :caption: Example
-    :lines: 12-37
+    :lines: 13-39
 
 If you are using a torch model with **no or fixed hyperparameters**, you can use
 :py:class:`~renate.models.renate_module.RenateWrapper`.
@@ -41,7 +41,7 @@ method, but simply reinstantiate your model and call :code:`load_state_dict`.
     :caption: Example
 
     def model_fn(model_state_url: Optional[Union[Path, str]] = None) -> RenateModule:
-        my_torch_model = torch.nn.Linear(28*28, 10)  # Instantiate your torch model.
+        my_torch_model = torch.nn.Linear(28 * 28, 10)  # Instantiate your torch model.
         model = RenateWrapper(my_torch_model)
         if model_state_url is not None:
             state_dict = torch.load(str(model_state_url))
@@ -67,7 +67,7 @@ such as data subsampling or splitting.
 
 .. literalinclude:: ../../examples/getting_started/renate_config.py
     :caption: Example
-    :lines: 41-71
+    :lines: 42-72
 
 Transforms
 ==========
@@ -112,5 +112,49 @@ These are optional as well but, if omitted, Renate will use :code:`train_transfo
 
 .. literalinclude:: ../../examples/getting_started/renate_config.py
     :caption: Example
-    :lines: 74-
+    :lines: 75-
 
+Custom Function Arguments
+=========================
+In many cases, the standard arguments passed to all functions described above are not sufficient.
+More arguments can be added by simply adding them to the interface (with some limitations).
+We will demonstrate this at the example of :code:`data_module_fn` but the same rules apply to all other functions
+introduced in this chapter.
+
+Let us assume we already have a config file in which we implemented a simple linear model:
+
+.. code-block:: python
+
+    def model_fn(model_state_url: Optional[Union[Path, str]] = None) -> RenateModule:
+        my_torch_model = torch.nn.Linear(28 * 28, 10)
+        model = RenateWrapper(my_torch_model)
+        if model_state_url is not None:
+            state_dict = torch.load(str(model_state_url))
+            model.load_state_dict(state_dict)
+        return model
+
+However, we have different datasets and each of them has different input and output dimensions.
+The natural change would be to change it to something like
+
+.. code-block:: python
+
+    def model_fn(num_inputs: int, num_outputs: int, model_state_url: Optional[Union[Path, str]] = None) -> RenateModule:
+        my_torch_model = torch.nn.Linear(num_inputs, num_outputs)
+        model = RenateWrapper(my_torch_model)
+        if model_state_url is not None:
+            state_dict = torch.load(str(model_state_url))
+            model.load_state_dict(state_dict)
+        return model
+
+And in fact, this is exactly how it works. However, there are few limitations:
+
+* Typing is required.
+* Only types allowed: ``bool``, ``float``, ``int``, ``str``, ``list``, and ``tuple``.
+  (typing with ``List``, ``Tuple`` or ``Optional`` is okay)
+
+How to set the actual values, will be discussed in
+:ref:`the next chapter <getting_started/how_to_run_training:custom function arguments>`.
+
+.. note::
+    You can use an argument with the same name in the different functions as long as they have the same typing.
+    The same value will provided to them.

--- a/doc/getting_started/how_to_run_training.rst
+++ b/doc/getting_started/how_to_run_training.rst
@@ -66,6 +66,7 @@ In both cases the urls can point to local folders or S3 locations.
 Putting everything together will result in a script like the following.
 
 .. literalinclude:: ../../examples/train_mlp_locally/start_training_with_er_without_hpo.py
+    :lines: 3-
 
 Once the training has been executed you will see some metrics printed on the screen (e.g., validation accuracy)
 and you will find the output of the training process in the folder specified. For more information about the
@@ -140,3 +141,26 @@ After defining these arguments it will be sufficient to run the script and wait 
 The output will be available in the location specified in :code:`output_state_url`.
 
 We provide an example of training on SageMaker with HPO at :doc:`../examples/train_classifier_sagemaker`.
+
+Custom Function Arguments
+=========================
+Now that we know how to run basic training jobs, we can discuss how to use custom defined function arguments.
+We are building upon the linear model example introduced in the
+:ref:`previous chapter <getting_started/how_to_renate_config:custom function arguments>` where we added
+``num_inputs`` and ``num_outputs`` to :code:`data_module_fn`.
+The values for these inputs are passed via the configuration alongside the other arguments.
+
+.. code-block:: python
+
+    config_space = {
+        # Define all remaining standard arguments as well
+        "num_inputs": 28 * 28,
+        "num_outputs": 10,
+    }
+
+While it does not make any sense for this example, we can also define ranges for our custom function arguments and
+automatically optimize them during hyperparameter optimization.
+
+.. note::
+    If you have functions defined with the same argument name, the value defined in the configuration will be passed
+    to both.

--- a/doc/getting_started/supported_algorithms.rst
+++ b/doc/getting_started/supported_algorithms.rst
@@ -32,7 +32,7 @@ using Renate (e.g., using :py:func:`renate.training.training.run_training_job`; 
      - A strong baseline that trains the model from scratch on a memory, which is maintained using a greedy class-balancing strategy. [`Paper <https://www.ecva.net/papers/eccv_2020/papers_ECCV/papers/123470511.pdf>`__]
    * - ``"Joint"``
      - :py:class:`JointLearner <renate.updaters.experimental.joint.JointLearner>`
-     - Retraining from scratch on all data seen so far. Used as an "upper bound" in experiments, inefficient for practical use.
+     - This method retrains a randomly initialized model each time from scratch on all data seen so far. Used as "upper bound" in experiments, inefficient for practical use.
    * - ``"FineTuning"``
-     - :py:class:`Learner <renate.updaters.experimental.learner.Learner>`
-     - Fine-tuning the existing model using the new data without any sort of mitigation for forgetting. Users as "lower bound" baseline in the experiments.
+     - :py:class:`Learner <renate.updaters.learner.Learner>`
+     - A simple method which trains the current model on only the new data without any sort of mitigation for forgetting. Used as "lower bound" baseline in experiments.

--- a/examples/benchmarking/class_incremental_learning_cifar10_der.py
+++ b/examples/benchmarking/class_incremental_learning_cifar10_der.py
@@ -1,11 +1,8 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from renate.benchmark.experimentation import execute_experiment_job, experiment_config_file
 
 
-def to_dense_str(value):
-    return str(value).replace(" ", "")
-
-
-dataset_name = "CIFAR10"
 config_space = {
     "updater": "DER",
     "optimizer": "SGD",
@@ -20,12 +17,11 @@ config_space = {
     "max_epochs": 50,
     "loss_normalization": 0,
     "loss_weight": 1.0,
-    "model_fn_model_name": "ResNet18CIFAR",
-    "data_module_fn_scenario_name": "ClassIncrementalScenario",
-    "data_module_fn_dataset_name": dataset_name,
-    "data_module_fn_val_size": 0,
-    "data_module_fn_class_groupings": to_dense_str([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]),
-    "transform_dataset_name": dataset_name,
+    "model_name": "ResNet18CIFAR",
+    "scenario_name": "ClassIncrementalScenario",
+    "dataset_name": "CIFAR10",
+    "val_size": 0,
+    "class_groupings": ((0, 1), (2, 3), (4, 5), (6, 7), (8, 9)),
 }
 
 for seed in range(10):

--- a/examples/getting_started/renate_config.py
+++ b/examples/getting_started/renate_config.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from typing import Callable, Literal, Optional
 
 import torch

--- a/examples/train_mlp_locally/renate_config.py
+++ b/examples/train_mlp_locally/renate_config.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
 from typing import Callable, Optional, Union
 

--- a/examples/train_mlp_locally/start_training_with_er_without_hpo.py
+++ b/examples/train_mlp_locally/start_training_with_er_without_hpo.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from renate.training import run_training_job
 
 configuration = {

--- a/examples/train_mlp_locally/start_training_with_hpo.py
+++ b/examples/train_mlp_locally/start_training_with_hpo.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from renate.training import run_training_job
 from renate.utils.config_spaces import config_space
 

--- a/examples/train_mlp_locally/start_training_without_hpo.py
+++ b/examples/train_mlp_locally/start_training_without_hpo.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from renate.training import run_training_job
 
 

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -198,18 +198,6 @@ def data_module_fn(
         val_size=val_size,
         seed=seed,
     )
-    if num_tasks is not None:
-        num_tasks = num_tasks
-    if class_groupings is not None:
-        class_groupings = class_groupings
-    if degrees is not None:
-        degrees = degrees
-    if input_dim is not None:
-        input_dim = input_dim
-    if feature_idx is not None:
-        feature_idx = feature_idx
-    if randomness is not None:
-        randomness = randomness
     return get_scenario(
         scenario_name=scenario_name,
         data_module=data_module,

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import ast
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -57,10 +56,10 @@ def model_fn(
     model_state_url: Optional[str] = None,
     updater: Optional[str] = None,
     model_name: Optional[str] = None,
-    num_inputs: Optional[str] = None,
-    num_outputs: Optional[str] = None,
-    num_hidden_layers: Optional[str] = None,
-    hidden_size: Optional[str] = None,
+    num_inputs: Optional[int] = None,
+    num_outputs: Optional[int] = None,
+    num_hidden_layers: Optional[int] = None,
+    hidden_size: Optional[Tuple[int]] = None,
 ) -> RenateModule:
     """Returns a model instance."""
     if model_name not in models:
@@ -71,12 +70,12 @@ def model_fn(
         model_kwargs["prediction_strategy"] = ICaRLClassificationStrategy()
     if model_name == "MultiLayerPerceptron":
         model_kwargs = {
-            "num_inputs": int(num_inputs),
-            "num_hidden_layers": int(num_hidden_layers),
-            "hidden_size": ast.literal_eval(hidden_size),
+            "num_inputs": num_inputs,
+            "num_hidden_layers": num_hidden_layers,
+            "hidden_size": hidden_size,
         }
     if num_outputs is not None:
-        model_kwargs["num_outputs"] = int(num_outputs)
+        model_kwargs["num_outputs"] = num_outputs
     if model_state_url is None:
         model = model_class(**model_kwargs)
     else:
@@ -185,9 +184,9 @@ def data_module_fn(
     seed: int,
     scenario_name: str,
     dataset_name: str,
-    val_size: str = "0.0",
+    val_size: float = 0.0,
     num_tasks: Optional[int] = None,
-    class_groupings: Optional[str] = None,
+    class_groupings: Optional[Tuple[Tuple[int]]] = None,
     degrees: Optional[Tuple[int]] = None,
     input_dim: Optional[Tuple[int]] = None,
     feature_idx: Optional[int] = None,
@@ -196,17 +195,17 @@ def data_module_fn(
     data_module = get_data_module(
         data_path=data_path,
         dataset_name=dataset_name,
-        val_size=float(val_size),
+        val_size=val_size,
         seed=seed,
     )
     if num_tasks is not None:
         num_tasks = num_tasks
     if class_groupings is not None:
-        class_groupings = ast.literal_eval(class_groupings)
+        class_groupings = class_groupings
     if degrees is not None:
-        degrees = ast.literal_eval(degrees)
+        degrees = degrees
     if input_dim is not None:
-        input_dim = ast.literal_eval(input_dim)
+        input_dim = input_dim
     if feature_idx is not None:
         feature_idx = feature_idx
     if randomness is not None:

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -186,12 +186,12 @@ def data_module_fn(
     scenario_name: str,
     dataset_name: str,
     val_size: str = "0.0",
-    num_tasks: Optional[str] = None,
+    num_tasks: Optional[int] = None,
     class_groupings: Optional[str] = None,
-    degrees: Optional[str] = None,
-    input_dim: Optional[str] = None,
-    feature_idx: Optional[str] = None,
-    randomness: Optional[str] = None,
+    degrees: Optional[Tuple[int]] = None,
+    input_dim: Optional[Tuple[int]] = None,
+    feature_idx: Optional[int] = None,
+    randomness: Optional[float] = None,
 ):
     data_module = get_data_module(
         data_path=data_path,
@@ -200,7 +200,7 @@ def data_module_fn(
         seed=seed,
     )
     if num_tasks is not None:
-        num_tasks = int(num_tasks)
+        num_tasks = num_tasks
     if class_groupings is not None:
         class_groupings = ast.literal_eval(class_groupings)
     if degrees is not None:
@@ -208,9 +208,9 @@ def data_module_fn(
     if input_dim is not None:
         input_dim = ast.literal_eval(input_dim)
     if feature_idx is not None:
-        feature_idx = int(feature_idx)
+        feature_idx = feature_idx
     if randomness is not None:
-        randomness = float(randomness)
+        randomness = randomness
     return get_scenario(
         scenario_name=scenario_name,
         data_module=data_module,

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -102,7 +102,7 @@ def get_scenario(
     chunk_id: int,
     seed: int,
     num_tasks: Optional[int] = None,
-    class_groupings: Optional[List[List[int]]] = None,
+    class_groupings: Optional[Tuple[Tuple[int]]] = None,
     degrees: Optional[List[int]] = None,
     input_dim: Optional[Union[List[int], Tuple[int], int]] = None,
     feature_idx: Optional[int] = None,

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -135,6 +135,19 @@ def get_updater_and_learner_kwargs(
     return updater_class, learner_kwargs
 
 
+def _cast_arguments(arguments: Dict[str, Dict[str, Any]], args_dict: Dict[str, str]) -> None:
+    """Casts all values in args_dict to the value specified in arguments."""
+    for argument_name, argument_kwargs in arguments.items():
+        if args_dict[argument_name] == "None":
+            args_dict[argument_name] = None
+        if args_dict[argument_name] is None:
+            continue
+        if argument_kwargs.get("true_type") == bool:
+            args_dict[argument_name] = args_dict[argument_name] == "True"
+        elif argument_kwargs.get("true_type") in [list, tuple]:
+            args_dict[argument_name] = ast.literal_eval(args_dict[argument_name])
+
+
 def parse_arguments(
     config_module: ModuleType, function_names: List[str], ignore_args: List[str]
 ) -> Tuple[argparse.Namespace, Dict[str, Any]]:
@@ -177,16 +190,7 @@ def parse_arguments(
                     },
                 )
     args = parser.parse_args()
-    args_dict = vars(args)
-    for argument_name, argument_kwargs in arguments.items():
-        if args_dict[argument_name] == "None":
-            args_dict[argument_name] = None
-        if args_dict[argument_name] is None:
-            continue
-        if argument_kwargs.get("true_type") == bool:
-            args_dict[argument_name] = args_dict[argument_name] == "True"
-        elif argument_kwargs.get("true_type") in [list, tuple]:
-            args_dict[argument_name] = ast.literal_eval(args_dict[argument_name])
+    _cast_arguments(arguments=arguments, args_dict=vars(args))
     return args, function_args
 
 
@@ -673,17 +677,25 @@ def get_function_kwargs(args: argparse.Namespace, function_args: Dict[str, Any])
     return {key: value for key, value in vars(args).items() if key in function_args}
 
 
-def get_data_module_fn_kwargs(config_module, config_space: Dict[str, Any]) -> Dict[str, Any]:
+def get_data_module_fn_kwargs(
+    config_module, config_space: Dict[str, Any], cast_arguments: Optional[bool] = False
+) -> Dict[str, Any]:
     """Returns the kwargs for a ``data_module_fn`` with defined arguments based on config_space."""
-    return _get_function_kwargs_helper(config_module, config_space, "data_module_fn", ["data_path"])
+    return _get_function_kwargs_helper(
+        config_module, config_space, "data_module_fn", ["data_path"], cast_arguments
+    )
 
 
-def get_model_fn_kwargs(config_module, config_space: Dict[str, Any]) -> Dict[str, Any]:
+def get_model_fn_kwargs(
+    config_module, config_space: Dict[str, Any], cast_arguments: Optional[bool] = False
+) -> Dict[str, Any]:
     """Returns the kwargs for a ``model_fn`` with defined arguments based on config_space."""
-    return _get_function_kwargs_helper(config_module, config_space, "model_fn", [])
+    return _get_function_kwargs_helper(config_module, config_space, "model_fn", [], cast_arguments)
 
 
-def get_transforms_kwargs(config_module, config_space: Dict[str, Any]) -> Dict[str, Callable]:
+def get_transforms_kwargs(
+    config_module, config_space: Dict[str, Any], cast_arguments: Optional[bool] = False
+) -> Dict[str, Callable]:
     """Returns the transforms based on config_space."""
     transform_fn_names = [
         "train_transform",
@@ -697,17 +709,28 @@ def get_transforms_kwargs(config_module, config_space: Dict[str, Any]) -> Dict[s
     for transform_fn_name in transform_fn_names:
         if hasattr(config_module, transform_fn_name):
             transforms[transform_fn_name] = getattr(config_module, transform_fn_name)(
-                **_get_function_kwargs_helper(config_module, config_space, transform_fn_name, [])
+                **_get_function_kwargs_helper(
+                    config_module, config_space, transform_fn_name, [], cast_arguments
+                )
             )
     return transforms
 
 
 def _get_function_kwargs_helper(
-    config_module, config_space: Dict[str, Any], function_name: str, ignore_args: List[str]
+    config_module,
+    config_space: Dict[str, Any],
+    function_name: str,
+    ignore_args: List[str],
+    cast_arguments: Optional[bool] = False,
 ) -> Dict[str, Any]:
     """Returns kwargs for function based on its interface."""
-    function_args = get_function_args(config_module, function_name, {}, ignore_args)
-    return {key: value for key, value in config_space.items() if key in function_args}
+    all_args = {}
+    function_args = get_function_args(config_module, function_name, all_args, ignore_args)
+    filtered_args = {key: value for key, value in config_space.items() if key in function_args}
+    if cast_arguments:
+        filtered_all_args = {key: value for key, value in all_args.items() if key in filtered_args}
+        _cast_arguments(arguments=filtered_all_args, args_dict=filtered_args)
+    return filtered_args
 
 
 def get_transforms_dict(

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -163,6 +163,15 @@ def parse_arguments(
                         if key != "argument_group"
                     },
                 )
+                print(
+                    argument_name,
+                    {
+                        key: value
+                        for key, value in argument_kwargs.items()
+                        if key != "argument_group"
+                    },
+                )
+
     return parser.parse_args(), function_args
 
 
@@ -768,12 +777,17 @@ def get_function_args(
             all_args[argument_name]["required"] = True
 
     for argument_name in new_args:
+        true_type = get_argument_type(arg_spec, argument_name)
         all_args[argument_name] = {
-            "type": get_argument_type(arg_spec, argument_name),
+            "type": str if true_type in [bool, list, tuple] else true_type,
             "argument_group": CUSTOM_ARGS_GROUP,
+            "true_type": true_type,
         }
         if argument_name in default_values:
-            all_args[argument_name]["default"] = default_values[argument_name]
+            default_value = default_values[argument_name]
+            if true_type in [bool, list, tuple]:
+                default_value = to_dense_str(default_value)
+            all_args[argument_name]["default"] = default_value
         else:
             all_args[argument_name]["required"] = True
     return arg_spec.args

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -767,7 +767,7 @@ def get_argument_type(arg_spec: inspect.FullArgSpec, argument_name: str) -> Type
     return argument_type
 
 
-def _to_dense_str(value: Union[bool, List, Tuple]) -> str:
+def to_dense_str(value: Union[bool, List, Tuple]) -> str:
     """Converts a variable to string without empty spaces."""
     return str(value).replace(" ", "")
 
@@ -820,7 +820,7 @@ def get_function_args(
         if argument_name in default_values:
             default_value = default_values[argument_name]
             if true_type in [bool, list, tuple] and default_value is not None:
-                default_value = _to_dense_str(default_value)
+                default_value = to_dense_str(default_value)
             all_args[argument_name]["default"] = default_value
         else:
             all_args[argument_name]["required"] = True

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -137,8 +137,17 @@ def get_updater_and_learner_kwargs(
     return updater_class, learner_kwargs
 
 
-def _cast_arguments(arguments: Dict[str, Dict[str, Any]], args_dict: Dict[str, str]) -> None:
-    """Casts all values in args_dict to the value specified in arguments."""
+def _cast_arguments_to_true_types(
+    arguments: Dict[str, Dict[str, Any]], args_dict: Dict[str, str]
+) -> None:
+    """Casts all values in args_dict to the value specified in arguments.
+
+    Booleans, lists, None, and tuples are passed as a string to the script and argsparse will not
+    convert them for us. After detecting the true types according to typing (typing is saved in
+    ``arguments``), we now explicitly cast our arguments.
+    After this step, ``args`` as a results of argparse.parse will contain the correct types and no
+    further typecasting is required.
+    """
     for argument_name, argument_kwargs in arguments.items():
         if args_dict[argument_name] == "None":
             args_dict[argument_name] = None
@@ -192,7 +201,7 @@ def parse_arguments(
                     },
                 )
     args = parser.parse_args()
-    _cast_arguments(arguments=arguments, args_dict=vars(args))
+    _cast_arguments_to_true_types(arguments=arguments, args_dict=vars(args))
     return args, function_args
 
 
@@ -731,7 +740,7 @@ def _get_function_kwargs_helper(
     filtered_args = {key: value for key, value in config_space.items() if key in function_args}
     if cast_arguments:
         filtered_all_args = {key: value for key, value in all_args.items() if key in filtered_args}
-        _cast_arguments(arguments=filtered_all_args, args_dict=filtered_args)
+        _cast_arguments_to_true_types(arguments=filtered_all_args, args_dict=filtered_args)
     return filtered_args
 
 

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import argparse
+import ast
 import inspect
 import sys
 from types import ModuleType
@@ -137,7 +138,19 @@ def get_updater_and_learner_kwargs(
 def parse_arguments(
     config_module: ModuleType, function_names: List[str], ignore_args: List[str]
 ) -> Tuple[argparse.Namespace, Dict[str, Any]]:
+    """Parses all input arguments.
 
+    Combines standard arguments with custom arguments in functions of Renate config.
+
+    Args:
+        config_module: Module containing function of which we extract arguments.
+        function_names: List of function names in module for which extract arguments.
+        ignore_args: List of arguments to be ignored since they are not passed via CLI.
+    Returns:
+        First return value are the passed arguments where strings are converted to Booleans, lists
+        and tuples. Second return value is a dictionary containing the arguments that will be passed
+        to all functions specified in ``function_names``.
+    """
     arguments = _standard_arguments()
     _add_hyperparameter_arguments(arguments)
     function_args = {}
@@ -160,19 +173,21 @@ def parse_arguments(
                     **{
                         key: value
                         for key, value in argument_kwargs.items()
-                        if key != "argument_group"
+                        if key != "argument_group" and key != "true_type"
                     },
                 )
-                print(
-                    argument_name,
-                    {
-                        key: value
-                        for key, value in argument_kwargs.items()
-                        if key != "argument_group"
-                    },
-                )
-
-    return parser.parse_args(), function_args
+    args = parser.parse_args()
+    args_dict = vars(args)
+    for argument_name, argument_kwargs in arguments.items():
+        if args_dict[argument_name] == "None":
+            args_dict[argument_name] = None
+        if args_dict[argument_name] is None:
+            continue
+        if argument_kwargs.get("true_type") == bool:
+            args_dict[argument_name] = args_dict[argument_name] == "True"
+        elif argument_kwargs.get("true_type") in [list, tuple]:
+            args_dict[argument_name] = ast.literal_eval(args_dict[argument_name])
+    return args, function_args
 
 
 def _standard_arguments() -> Dict[str, Dict[str, Any]]:
@@ -258,6 +273,7 @@ def _standard_arguments() -> Dict[str, Dict[str, Any]]:
             "help": "Enables the early stopping of the optimization. Default: "
             f"{defaults.EARLY_STOPPING}.",
             "argument_group": OPTIONAL_ARGS_GROUP,
+            "true_type": bool,
         },
         "deterministic_trainer": {
             "type": str,
@@ -266,12 +282,15 @@ def _standard_arguments() -> Dict[str, Dict[str, Any]]:
             "help": "Enables deterministic training which may be slower. Default: "
             f"{defaults.DETERMINISTIC_TRAINER}.",
             "argument_group": OPTIONAL_ARGS_GROUP,
+            "true_type": bool,
         },
         "prepare_data": {
-            "type": int,
-            "default": 1,
-            "help": "Whether to call DataModule.prepare_data(). Default: 1.",
+            "type": str,
+            "default": "True",
+            "choices": ["True", "False"],
+            "help": "Whether to call DataModule.prepare_data(). Default: True.",
             "argument_group": DO_NOT_CHANGE_GROUP,
+            "true_type": bool,
         },
         "st_checkpoint_dir": {
             "type": str,
@@ -715,6 +734,8 @@ def get_transforms_dict(
 
 
 def get_argument_type(arg_spec: inspect.FullArgSpec, argument_name: str) -> Type:
+    """Returns the type of the argument with ``argument_name``."""
+
     def raise_error(arg_type, arg_name):
         raise TypeError(f"Type {arg_type} is not supported (argument {arg_name}).")
 
@@ -726,7 +747,15 @@ def get_argument_type(arg_spec: inspect.FullArgSpec, argument_name: str) -> Type
                 argument_name
             ].__args__[1] != type(None):
                 raise_error(arg_spec.annotations[argument_name], argument_name)
-            argument_type = arg_spec.annotations[argument_name].__args__[0]
+            if hasattr(arg_spec.annotations[argument_name].__args__[0], "__origin__"):
+                if arg_spec.annotations[argument_name].__args__[0].__origin__ in [list, tuple]:
+                    argument_type = arg_spec.annotations[argument_name].__args__[0].__origin__
+                else:
+                    raise_error(arg_spec.annotations[argument_name], argument_name)
+            else:
+                argument_type = arg_spec.annotations[argument_name].__args__[0]
+            if arg_spec.annotations[argument_name].__origin__ in [list, tuple]:
+                argument_type = arg_spec.annotations[argument_name].__origin__
         elif arg_spec.annotations[argument_name].__origin__ in [list, tuple]:
             argument_type = arg_spec.annotations[argument_name].__origin__
         else:
@@ -736,6 +765,11 @@ def get_argument_type(arg_spec: inspect.FullArgSpec, argument_name: str) -> Type
     if argument_type not in [int, bool, float, str, list, tuple]:
         raise_error(argument_type, argument_name)
     return argument_type
+
+
+def _to_dense_str(value: Union[bool, List, Tuple]) -> str:
+    """Converts a variable to string without empty spaces."""
+    return str(value).replace(" ", "")
 
 
 def get_function_args(
@@ -785,8 +819,8 @@ def get_function_args(
         }
         if argument_name in default_values:
             default_value = default_values[argument_name]
-            if true_type in [bool, list, tuple]:
-                default_value = to_dense_str(default_value)
+            if true_type in [bool, list, tuple] and default_value is not None:
+                default_value = _to_dense_str(default_value)
             all_args[argument_name]["default"] = default_value
         else:
             all_args[argument_name]["required"] = True

--- a/src/renate/cli/run_training.py
+++ b/src/renate/cli/run_training.py
@@ -99,9 +99,6 @@ class ModelUpdaterCLI:
             ignore_args=["data_path", "model_state_url"],
         )
 
-        args.early_stopping = args.early_stopping == "True"
-        args.deterministic_trainer = args.deterministic_trainer == "True"
-
         seed_everything(args.seed)
         self._prepare_data_state_model(args)
 

--- a/src/renate/memory/buffer.py
+++ b/src/renate/memory/buffer.py
@@ -11,7 +11,6 @@ from renate import defaults
 from renate.types import NestedTensors
 from renate.utils.pytorch import get_generator
 
-
 DataDict = Dict[str, torch.Tensor]
 Index = Union[int, slice]
 

--- a/src/renate/memory/storage.py
+++ b/src/renate/memory/storage.py
@@ -5,6 +5,7 @@ import os
 from typing import Any, Tuple
 
 import torch
+
 from renate.types import NestedTensors
 
 

--- a/src/renate/training/training.py
+++ b/src/renate/training/training.py
@@ -31,7 +31,7 @@ from syne_tune.util import experiment_path
 
 import renate
 from renate import defaults
-from renate.cli.parsing_functions import _to_dense_str, get_data_module_fn_kwargs
+from renate.cli.parsing_functions import to_dense_str, get_data_module_fn_kwargs
 from renate.utils.file import move_to_uri
 from renate.utils.module import get_and_prepare_data_module, import_module
 from renate.utils.syne_tune import (
@@ -143,7 +143,7 @@ def run_training_job(
     ), f"Backend {backend} is not in {defaults.SUPPORTED_BACKEND}."
     for key, value in config_space.items():
         if isinstance(value, (bool, list, tuple)):
-            config_space[key] = _to_dense_str(value)
+            config_space[key] = to_dense_str(value)
     if backend == "local":
         return _execute_training_and_tuning_job_locally(
             input_state_url=input_state_url,

--- a/src/renate/training/training.py
+++ b/src/renate/training/training.py
@@ -31,7 +31,7 @@ from syne_tune.util import experiment_path
 
 import renate
 from renate import defaults
-from renate.cli.parsing_functions import get_data_module_fn_kwargs
+from renate.cli.parsing_functions import _to_dense_str, get_data_module_fn_kwargs
 from renate.utils.file import move_to_uri
 from renate.utils.module import get_and_prepare_data_module, import_module
 from renate.utils.syne_tune import (
@@ -141,6 +141,9 @@ def run_training_job(
     assert (
         backend in defaults.SUPPORTED_BACKEND
     ), f"Backend {backend} is not in {defaults.SUPPORTED_BACKEND}."
+    for key, value in config_space.items():
+        if isinstance(value, (bool, list, tuple)):
+            config_space[key] = _to_dense_str(value)
     if backend == "local":
         return _execute_training_and_tuning_job_locally(
             input_state_url=input_state_url,
@@ -513,7 +516,7 @@ def _execute_training_and_tuning_job_locally(
     config_space["updater"] = updater
     config_space["max_epochs"] = max_epochs
     config_space["config_file"] = config_file
-    config_space["prepare_data"] = 0
+    config_space["prepare_data"] = False
     config_space["chunk_id"] = chunk_id
     config_space["task_id"] = task_id
     config_space["working_directory"] = working_directory

--- a/src/renate/training/training.py
+++ b/src/renate/training/training.py
@@ -425,7 +425,7 @@ def _verify_validation_set_for_hpo_and_checkpointing(
     data_module = get_and_prepare_data_module(
         config_module,
         data_path=defaults.data_folder(working_directory),
-        **get_data_module_fn_kwargs(config_module, config_space),
+        **get_data_module_fn_kwargs(config_module, config_space, cast_arguments=True),
     )
     data_module.setup()
     val_exists = data_module.val_data() is not None

--- a/src/renate/updaters/avalanche/plugins.py
+++ b/src/renate/updaters/avalanche/plugins.py
@@ -39,8 +39,6 @@ class RenateCheckpointPlugin(CheckpointPlugin):
     def __init__(
         self,
         storage: RenateFileSystemCheckpointStorage,
-        # metric: str,
-        # mode: defaults.SUPPORTED_TUNING_MODE_TYPE,
         map_location: Optional[Union[str, torch.device, Dict[str, str]]] = None,
     ):
         super().__init__(storage=storage, map_location=map_location)

--- a/src/renate/utils/module.py
+++ b/src/renate/utils/module.py
@@ -92,7 +92,7 @@ def get_and_prepare_data_module(config_module: ModuleType, **kwargs: Any) -> Ren
 
 def get_and_setup_data_module(
     config_module: ModuleType,
-    prepare_data: int,
+    prepare_data: bool,
     **kwargs: Any,
 ) -> RenateDataModule:
     """Creates data module and possibly calls the prepare_data function needed for setup"""

--- a/test/renate/benchmark/test_experimentation.py
+++ b/test/renate/benchmark/test_experimentation.py
@@ -13,7 +13,7 @@ def experiment_job_kwargs():
     return {
         "backend": "local",
         "config_file": str(Path(__file__).parent.parent / "renate_config_files" / "config.py"),
-        "config_space": {"updater": "ER", "use_scenario": "True", "max_epochs": 5},
+        "config_space": {"updater": "ER", "use_scenario": True, "max_epochs": 5},
         "mode": "max",
         "metric": "val_accuracy",
         "num_updates": 2,

--- a/test/renate/benchmark/test_experimentation_config.py
+++ b/test/renate/benchmark/test_experimentation_config.py
@@ -35,7 +35,7 @@ def test_model_fn(model_name, expected_model_class):
         num_inputs=1 if model_name == "MultiLayerPerceptron" else None,
         num_outputs=1 if model_name == "MultiLayerPerceptron" else None,
         num_hidden_layers=1 if model_name == "MultiLayerPerceptron" else None,
-        hidden_size="1" if model_name == "MultiLayerPerceptron" else None,
+        hidden_size=1 if model_name == "MultiLayerPerceptron" else None,
     )
     assert isinstance(model, expected_model_class)
 
@@ -76,7 +76,7 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
         (
             "ClassIncrementalScenario",
             "CIFAR10",
-            {"class_groupings": "[[0,1],[2,3,4],[5,6]]"},
+            {"class_groupings": ((0, 1), (2, 3, 4), (5, 6))},
             ClassIncrementalScenario,
             3,
         ),
@@ -90,15 +90,15 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
         (
             "ImageRotationScenario",
             "MNIST",
-            {"degrees": "[0,90,180]"},
+            {"degrees": (0, 90, 180)},
             ImageRotationScenario,
             3,
         ),
-        ("BenchmarkScenario", "CLEAR10", {"num_tasks": "5"}, BenchmarkScenario, 5),
+        ("BenchmarkScenario", "CLEAR10", {"num_tasks": 5}, BenchmarkScenario, 5),
         (
             "PermutationScenario",
             "MNIST",
-            {"num_tasks": "3", "input_dim": "(1,28,28)"},
+            {"num_tasks": 3, "input_dim": (1, 28, 28)},
             PermutationScenario,
             3,
         ),
@@ -106,9 +106,9 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
             "FeatureSortingScenario",
             "MNIST",
             {
-                "num_tasks": "5",
-                "feature_idx": "0",
-                "randomness": "0.3",
+                "num_tasks": 5,
+                "feature_idx": 0,
+                "randomness": 0.3,
             },
             FeatureSortingScenario,
             5,
@@ -116,10 +116,7 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
         (
             "HueShiftScenario",
             "CIFAR10",
-            {
-                "num_tasks": "3",
-                "randomness": "0.5",
-            },
+            {"num_tasks": 3, "randomness": 0.5},
             HueShiftScenario,
             3,
         ),
@@ -155,7 +152,12 @@ def test_data_module_fn(
     )
     assert isinstance(scenario, expected_scenario_class)
     if expected_scenario_class == ClassIncrementalScenario:
-        assert str(scenario._class_groupings).replace(" ", "") == scenario_kwargs["class_groupings"]
+        assert scenario._class_groupings == scenario_kwargs["class_groupings"]
+    elif expected_scenario_class == FeatureSortingScenario:
+        scenario._feature_idx = scenario_kwargs["feature_idx"]
+        scenario._randomness = scenario_kwargs["randomness"]
+    elif expected_scenario_class == HueShiftScenario:
+        scenario._randomness = scenario_kwargs["randomness"]
     assert scenario._num_tasks == expected_num_tasks
 
 

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -75,7 +75,7 @@ def test_get_argument_type():
     ids=("No all_args, no ignore_args", "no all_args", "all_args"),
 )
 def test_get_function_args(all_args, ignore_args):
-    expected_args = ["data_path", "chunk_id", "val_size", "seed", "use_scenario"]
+    expected_args = ["data_path", "chunk_id", "val_size", "seed", "use_scenario", "class_groupings"]
     expected_all_args = {
         **all_args,
         **{
@@ -84,6 +84,11 @@ def test_get_function_args(all_args, ignore_args):
             "val_size": {"type": str, "argument_group": CUSTOM_ARGS_GROUP, "default": "0.0"},
             "seed": {"type": int, "argument_group": CUSTOM_ARGS_GROUP, "default": 0},
             "use_scenario": {"type": str, "argument_group": CUSTOM_ARGS_GROUP, "default": "False"},
+            "class_groupings": {
+                "type": str,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": "((0,1),(2,3,4))",
+            },
         },
     }
     for arg in ignore_args:
@@ -95,6 +100,9 @@ def test_get_function_args(all_args, ignore_args):
         ignore_args=ignore_args,
     )
     assert args == expected_args
+    print("all_args:", all_args)
+    print()
+    print("expected", expected_all_args)
     assert all_args == expected_all_args
 
 

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -13,6 +13,7 @@ from renate.cli.parsing_functions import (
     get_data_module_fn_kwargs,
     get_function_args,
     get_model_fn_kwargs,
+    to_dense_str,
 )
 from renate.utils.module import import_module
 
@@ -84,6 +85,7 @@ def test_get_function_args(all_args, ignore_args):
         "class_groupings",
         "optional_tuple",
         "optional_float",
+        "list_param",
     ]
     expected_all_args = {
         **all_args,
@@ -135,6 +137,12 @@ def test_get_function_args(all_args, ignore_args):
                 "argument_group": CUSTOM_ARGS_GROUP,
                 "default": None,
                 "true_type": float,
+            },
+            "list_param": {
+                "type": str,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": "[1,2]",
+                "true_type": list,
             },
         },
     }
@@ -194,14 +202,25 @@ def test_get_function_args_prefers_required_true():
 def test_get_fn_kwargs_helper_functions():
     """Tests whether the different helper functions correctly create kwargs given a dictionary
     and the Python function."""
-    config_space = {
+    expected_data_module_kwargs = {
         "data_path": "home/data/path",
+        "class_groupings": ((1, 2), (3, 4)),
+        "use_scenario": False,
+        "optional_float": None,
+    }
+    config_space = {
+        "data_path": expected_data_module_kwargs["data_path"],
         "model_state_url": "home/model/state",
         "unused_config": 1,
+        "class_groupings": to_dense_str(expected_data_module_kwargs["class_groupings"]),
+        "use_scenario": to_dense_str(expected_data_module_kwargs["use_scenario"]),
+        "optional_float": to_dense_str(expected_data_module_kwargs["optional_float"]),
     }
     data_module_kwargs = get_data_module_fn_kwargs(
-        config_module=config_module, config_space=config_space
+        config_module=config_module, config_space=config_space, cast_arguments=True
     )
-    assert data_module_kwargs == {"data_path": config_space["data_path"]}
-    model_kwargs = get_model_fn_kwargs(config_module=config_module, config_space=config_space)
+    assert data_module_kwargs == expected_data_module_kwargs
+    model_kwargs = get_model_fn_kwargs(
+        config_module=config_module, config_space=config_space, cast_arguments=True
+    )
     assert model_kwargs == {"model_state_url": config_space["model_state_url"]}

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -54,9 +54,10 @@ def test_get_argument_type():
         "no_annotation_param": r"Missing type annotation for argument no_annotation_param.",
     }
     if sys.version_info.minor >= 9:
-        expected_errors[
-            "optional_dict_param"
-        ] = r"Type typing.Optional\[typing.Dict\[str, str\]\] is not supported \(argument optional_dict_param\)."
+        expected_errors["optional_dict_param"] = (
+            r"Type typing.Optional\[typing.Dict\[str, str\]\] is not supported "
+            r"\(argument optional_dict_param\)."
+        )
     for argument_name, expected_type in expected_types.items():
         assert get_argument_type(arg_spec=arg_spec, argument_name=argument_name) == expected_type
 

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -75,19 +75,66 @@ def test_get_argument_type():
     ids=("No all_args, no ignore_args", "no all_args", "all_args"),
 )
 def test_get_function_args(all_args, ignore_args):
-    expected_args = ["data_path", "chunk_id", "val_size", "seed", "use_scenario", "class_groupings"]
+    expected_args = [
+        "data_path",
+        "chunk_id",
+        "val_size",
+        "seed",
+        "use_scenario",
+        "class_groupings",
+        "optional_tuple",
+        "optional_float",
+    ]
     expected_all_args = {
         **all_args,
         **{
-            "data_path": {"type": str, "argument_group": CUSTOM_ARGS_GROUP, "required": True},
-            "chunk_id": {"type": int, "argument_group": CUSTOM_ARGS_GROUP, "default": None},
-            "val_size": {"type": str, "argument_group": CUSTOM_ARGS_GROUP, "default": "0.0"},
-            "seed": {"type": int, "argument_group": CUSTOM_ARGS_GROUP, "default": 0},
-            "use_scenario": {"type": str, "argument_group": CUSTOM_ARGS_GROUP, "default": "False"},
+            "data_path": {
+                "type": str,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "required": True,
+                "true_type": str,
+            },
+            "chunk_id": {
+                "type": int,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": None,
+                "true_type": int,
+            },
+            "val_size": {
+                "type": float,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": 0.0,
+                "true_type": float,
+            },
+            "seed": {
+                "type": int,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": 0,
+                "true_type": int,
+            },
+            "use_scenario": {
+                "type": str,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": "False",
+                "true_type": bool,
+            },
             "class_groupings": {
                 "type": str,
                 "argument_group": CUSTOM_ARGS_GROUP,
                 "default": "((0,1),(2,3,4))",
+                "true_type": tuple,
+            },
+            "optional_tuple": {
+                "type": str,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": None,
+                "true_type": tuple,
+            },
+            "optional_float": {
+                "type": float,
+                "argument_group": CUSTOM_ARGS_GROUP,
+                "default": None,
+                "true_type": float,
             },
         },
     }
@@ -100,9 +147,6 @@ def test_get_function_args(all_args, ignore_args):
         ignore_args=ignore_args,
     )
     assert args == expected_args
-    print("all_args:", all_args)
-    print()
-    print("expected", expected_all_args)
     assert all_args == expected_all_args
 
 

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -33,6 +33,7 @@ def test_get_argument_type():
         list_of_float_lists: List[List[float]],
         no_annotation_param,
         optional_str_param: Optional[str] = None,
+        optional_dict_param: Optional[Dict[str, str]] = None,
     ):
         pass
 
@@ -47,6 +48,8 @@ def test_get_argument_type():
     expected_errors = {
         "dict_param": r"Type typing.Dict\[str, int\] is not supported \(argument dict_param\).",
         "union_param": r"Type typing.Union\[str, int\] is not supported \(argument union_param\).",
+        "optional_dict_param": r"Type typing.Union\[typing.Dict\[str, str\], NoneType\] is not "
+        r"supported \(argument optional_dict_param\).",
         "no_annotation_param": r"Missing type annotation for argument no_annotation_param.",
     }
     for argument_name, expected_type in expected_types.items():

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import inspect
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -52,6 +53,10 @@ def test_get_argument_type():
         r"supported \(argument optional_dict_param\).",
         "no_annotation_param": r"Missing type annotation for argument no_annotation_param.",
     }
+    if sys.version_info.minor >= 9:
+        expected_errors[
+            "optional_dict_param"
+        ] = r"Type typing.Optional\[typing.Dict\[str, str\]\] is not supported \(argument optional_dict_param\)."
     for argument_name, expected_type in expected_types.items():
         assert get_argument_type(arg_spec=arg_spec, argument_name=argument_name) == expected_type
 

--- a/test/renate/memory/test_storage.py
+++ b/test/renate/memory/test_storage.py
@@ -1,8 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import torch
-
 import pytest
+import torch
 
 from renate.memory.storage import MemoryMappedTensorStorage
 

--- a/test/renate/renate_config_files/config.py
+++ b/test/renate/renate_config_files/config.py
@@ -27,6 +27,7 @@ def data_module_fn(
     class_groupings: Tuple[Tuple[int]] = ((0, 1), (2, 3, 4)),
     optional_tuple: Optional[Tuple[float]] = None,
     optional_float: Optional[float] = None,
+    list_param: list = [1, 2],
 ) -> RenateDataModule:
     data_module = DummyTorchVisionDataModule(transform=None, val_size=float(val_size), seed=seed)
     if use_scenario == "True":

--- a/test/renate/renate_config_files/config.py
+++ b/test/renate/renate_config_files/config.py
@@ -29,8 +29,8 @@ def data_module_fn(
     optional_float: Optional[float] = None,
     list_param: list = [1, 2],
 ) -> RenateDataModule:
-    data_module = DummyTorchVisionDataModule(transform=None, val_size=float(val_size), seed=seed)
-    if use_scenario == "True":
+    data_module = DummyTorchVisionDataModule(transform=None, val_size=val_size, seed=seed)
+    if use_scenario:
         return ClassIncrementalScenario(
             data_module=data_module,
             chunk_id=chunk_id,

--- a/test/renate/renate_config_files/config.py
+++ b/test/renate/renate_config_files/config.py
@@ -21,10 +21,12 @@ def model_fn(model_state_url: Optional[str] = None) -> RenateModule:
 def data_module_fn(
     data_path: str,
     chunk_id: Optional[int] = None,
-    val_size: str = "0.0",
+    val_size: float = 0.0,
     seed: int = 0,
-    use_scenario: str = "False",
+    use_scenario: bool = False,
     class_groupings: Tuple[Tuple[int]] = ((0, 1), (2, 3, 4)),
+    optional_tuple: Optional[Tuple[float]] = None,
+    optional_float: Optional[float] = None,
 ) -> RenateDataModule:
     data_module = DummyTorchVisionDataModule(transform=None, val_size=float(val_size), seed=seed)
     if use_scenario == "True":

--- a/test/renate/renate_config_files/config.py
+++ b/test/renate/renate_config_files/config.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
@@ -24,12 +24,13 @@ def data_module_fn(
     val_size: str = "0.0",
     seed: int = 0,
     use_scenario: str = "False",
+    class_groupings: Tuple[Tuple[int]] = ((0, 1), (2, 3, 4)),
 ) -> RenateDataModule:
     data_module = DummyTorchVisionDataModule(transform=None, val_size=float(val_size), seed=seed)
     if use_scenario == "True":
         return ClassIncrementalScenario(
             data_module=data_module,
             chunk_id=chunk_id,
-            class_groupings=[[0, 1], [2, 3, 4]],
+            class_groupings=class_groupings,
         )
     return data_module


### PR DESCRIPTION
Previously, custom arguments had to be of type `str` which required conversion. This PR will allow using types `int`, `float`, `bool`, `tuple`, and `list`.

Documentation was updated to reflect our changes made for custom function arguments.

Addresses #115 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
