### PR TITLE
add initial integ test workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,8 +33,7 @@ jobs:
 
         target_directory = 'test/integration_tests/configs/suites/quick'
         files = [f for f in os.listdir(target_directory) if os.path.isfile(os.path.join(target_directory, f))]
-        matrix = {'file': files}
-        matrix_json = json.dumps(matrix)
+        matrix_json = json.dumps(files)
         print(matrix_json)
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
@@ -49,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: ${{ fromJSON(needs.prepare.outputs.matrix.file)}}
+        suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
     steps:
      - name: run tests
        run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,11 +48,10 @@ jobs:
 
   tests:
     needs: prepare
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
-    steps:
-     - name: run tests
-       run: |
-         echo ${{ matrix.suite }}  
+    uses: ./.github/workflows/run_renate.yml
+    with:
+      script-path: test/integration_tests/run_quick_test.py --test-file ${{ matrix.suite }}
+

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,12 +18,15 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x
     - name: Prepare Inputs
+      id: set-matrix
       run: |
         import os
         import json
@@ -45,3 +48,14 @@ jobs:
 #    outputs:
 #      matrix: ${{ steps.set-matrix.outputs.suite }}
 
+
+  tests:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
+    steps:
+     - name: run tests
+       run: |
+         echo ${{ matrix.suite }}  

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,50 @@
+name: Integration Tests
+
+# All tests in this file:
+# 1. Run against every PR
+# 2. Do not require AWS credentials (We only run the tests that require credentials on code that has been approved and merged to main)
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  prepare:
+  - name: Parse test suite
+  - uses: actions/checkout@v3
+  - uses: actions/setup-python@v2
+    with:
+      python-version: 3.x
+    run: |
+      import os
+      import json
+
+      target_directory = 'test/integration_tests/configs/suites/quick'
+      files = [f for f in os.listdir(target_directory) if os.path.isfile(os.path.join(target_directory, f))]
+      matrix = {'file': files}
+      matrix_json = json.dumps(matrix)
+      print(matrix_json)
+      with open('matrix.json', 'w') as f:
+          f.write(matrix_json)
+
+#      print(f"::set-output name=matrix::{matrix_json}")
+  - uses: actions/upload-artifact@v3
+    with:
+       name: matrix
+       path: matrix.json
+#    outputs:
+#      matrix: ${{ steps.set-matrix.outputs.suite }}
+
+   tests:
+     needs: prepare
+     strategy:
+       matrix:
+        suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
+     run: |
+       echo ${{ matrix.file }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,7 +38,7 @@ jobs:
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
         
-        os.environ["GITHUB_OUTPUT"] += f"matrix={matrix_json}"
+        os.environ["GITHUB_OUTPUT"] = f"matrix={matrix_json}"
 
       shell: python
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,5 +54,6 @@ jobs:
         suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
     uses: ./.github/workflows/run_renate.yml
     with:
-      script-path: test/integration_tests/run_quick_test.py --test-file ${{ matrix.suite }}
+      path: test/integration_tests
+      script: run_quick_test.py --test-file ${{ matrix.suite }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,7 +38,7 @@ jobs:
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
         
-        print(f"::set-output name=matrix::{matrix_json}")
+        os.environ["GITHUB_OUTPUT"] += f"matrix={matrix_json}"
 
       shell: python
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,7 +38,10 @@ jobs:
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
         
-        os.environ["GITHUB_OUTPUT"] = f"matrix={matrix_json}"
+        name = "matrix"
+        value = matrix_json
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+          print(f'{name}={value}', file=fh)
 
       shell: python
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,37 +14,32 @@ on:
       - main
       - dev
 
+
 jobs:
   prepare:
-  - name: Parse test suite
-  - uses: actions/checkout@v3
-  - uses: actions/setup-python@v2
-    with:
-      python-version: 3.x
-    run: |
-      import os
-      import json
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - run: |
+        import os
+        import json
 
-      target_directory = 'test/integration_tests/configs/suites/quick'
-      files = [f for f in os.listdir(target_directory) if os.path.isfile(os.path.join(target_directory, f))]
-      matrix = {'file': files}
-      matrix_json = json.dumps(matrix)
-      print(matrix_json)
-      with open('matrix.json', 'w') as f:
-          f.write(matrix_json)
+        target_directory = 'test/integration_tests/configs/suites/quick'
+        files = [f for f in os.listdir(target_directory) if os.path.isfile(os.path.join(target_directory, f))]
+        matrix = {'file': files}
+        matrix_json = json.dumps(matrix)
+        print(matrix_json)
+        with open('matrix.json', 'w') as f:
+            f.write(matrix_json)
 
 #      print(f"::set-output name=matrix::{matrix_json}")
-  - uses: actions/upload-artifact@v3
-    with:
-       name: matrix
-       path: matrix.json
+    - uses: actions/upload-artifact@v3
+      with:
+         name: matrix
+         path: matrix.json
 #    outputs:
 #      matrix: ${{ steps.set-matrix.outputs.suite }}
 
-   tests:
-     needs: prepare
-     strategy:
-       matrix:
-        suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
-     run: |
-       echo ${{ matrix.file }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,15 +38,15 @@ jobs:
         print(matrix_json)
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
+        
+        print(f"::set-output name=matrix::{matrix_json}")
+
       shell: python
 
-#      print(f"::set-output name=matrix::{matrix_json}")
     - uses: actions/upload-artifact@v3
       with:
          name: matrix
          path: matrix.json
-#    outputs:
-#      matrix: ${{ steps.set-matrix.outputs.suite }}
 
 
   tests:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,7 +23,8 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x
-    - run: |
+    - name: Prepare Inputs
+      run: |
         import os
         import json
 
@@ -34,6 +35,7 @@ jobs:
         print(matrix_json)
         with open('matrix.json', 'w') as f:
             f.write(matrix_json)
+      shell: python
 
 #      print(f"::set-output name=matrix::{matrix_json}")
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
+        suite: ${{ fromJSON(needs.prepare.outputs.matrix.file)}}
     steps:
      - name: run tests
        run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -43,11 +43,6 @@ jobs:
 
       shell: python
 
-    - uses: actions/upload-artifact@v3
-      with:
-         name: matrix
-         path: matrix.json
-
 
   tests:
     needs: prepare

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,6 +49,7 @@ jobs:
   tests:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         suite: ${{ fromJSON(needs.prepare.outputs.matrix)}}
     uses: ./.github/workflows/run_renate.yml

--- a/.github/workflows/run_renate.yml
+++ b/.github/workflows/run_renate.yml
@@ -7,7 +7,10 @@ permissions:
 on:
   workflow_call:
     inputs:
-      script-path:
+      path:
+        required: true
+        type: string
+      script:
         required: true
         type: string
       requires-aws-credentials:
@@ -53,4 +56,6 @@ jobs:
         run: ${{ inputs.additional-command }}
       - name: Run Renate Script
         run: |
-          python ${{ inputs.script-path }}
+          cd ${{ inputs.path }}
+          python ${{ inputs.script }}
+          cd ~

--- a/.github/workflows/run_renate.yml
+++ b/.github/workflows/run_renate.yml
@@ -1,0 +1,55 @@
+name: Run Renate
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+on:
+  workflow_call:
+    inputs:
+      script-path:
+        required: true
+        type: string
+      requires-aws-credentials:
+        required: false
+        type: boolean
+      timeout-minutes:
+        required: false
+        type: number
+    secrets:
+      PROD_AWS_END_TO_END_TEST_ROLE_ARN:
+        required: false
+
+env:
+  AWS_DEFAULT_REGION: us-west-2
+  SCRIPT_PATH: ${{ inputs.script-path }}
+  AWS_ROLE: ${{ secrets.PROD_AWS_END_TO_END_TEST_ROLE_ARN }}
+
+jobs:
+  run:
+    runs-on: Renate_ubuntu-latest_16-core
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - name: Configure AWS Credentials (if required)
+        if: ${{ inputs.requires-aws-credentials == true }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_END_TO_END_TEST_ROLE_ARN }}
+          role-session-name: integtestsession
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Install Renate
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.'
+      - name: Run optional custom command
+        if: ${{ inputs.additional-command != '' }}
+        run: ${{ inputs.additional-command }}
+      - name: Run Renate Script
+        run: |
+          python ${{ inputs.script-path }}

--- a/.github/workflows/run_renate.yml
+++ b/.github/workflows/run_renate.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.'
+          python -m pip install pytest avalanche-lib
       - name: Run optional custom command
         if: ${{ inputs.additional-command != '' }}
         run: ${{ inputs.additional-command }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**/__pycache__/
+.DS_Store
+*.egg-info
+std.out
+
+renate_working_dir/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,0 @@
-**/__pycache__/
-.DS_Store
-*.egg-info
-std.out
-tmp/
-
-renate_working_dir/
-

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 *.egg-info
 std.out
+tmp/
 
 renate_working_dir/
 

--- a/test/integration_tests/configs/suites/quick/avalanche-er.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-avalanche-er",
-  "expected_accuracy": [0.738, 0.4185]
+  "expected_accuracy": [0.141, 0.679]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-er.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-avalanche-er",
-  "expected_accuracy": [0.141, 0.679]
+  "expected_accuracy": [0.14100000262260437, 0.6794999837875366]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
-  "expected_accuracy": [0.729, 0.958]
+  "expected_accuracy": [0.7293999791145325, 0.958899974822998]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
-  "expected_accuracy": [0.7423, 0.9603]
+  "expected_accuracy": [0.729, 0.958]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-icarl.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-icarl.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-avalanche-icarl",
-  "expected_accuracy": [0.998, 0.5656]
+  "expected_accuracy": [0.9981087446212769, 0.5656219124794006]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-icarl.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-icarl.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-avalanche-icarl",
-  "expected_accuracy": [0.999054, 0.56954]
+  "expected_accuracy": [0.998, 0.5656]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-lwf.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-lwf.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "permutation-mlp-avalanche-lwf",
-  "expected_accuracy": [0.752, 0.9607]
+  "expected_accuracy": [0.7526999711990356, 0.9607999920845032]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-lwf.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-lwf.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "permutation-mlp-avalanche-lwf",
-  "expected_accuracy": [0.7202, 0.9647]
+  "expected_accuracy": [0.752, 0.9607]
 }

--- a/test/integration_tests/configs/suites/quick/cls-er.json
+++ b/test/integration_tests/configs/suites/quick/cls-er.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-cls-er",
-  "expected_accuracy": [0.9858, 0.97404]
+  "expected_accuracy": [0.9858155846595764, 0.9740450382232666]
 }

--- a/test/integration_tests/configs/suites/quick/cls-er.json
+++ b/test/integration_tests/configs/suites/quick/cls-er.json
@@ -5,5 +5,5 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-cls-er",
-  "expected_accuracy": [0.985816, 0.975514]
+  "expected_accuracy": [0.9858, 0.97404]
 }

--- a/test/integration_tests/configs/suites/quick/der.json
+++ b/test/integration_tests/configs/suites/quick/der.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "feature-sorting-mlp-der",
-  "expected_accuracy": [0.3400, 0.3254]
+  "expected_accuracy": [0.35339, 0.3086]
 }

--- a/test/integration_tests/configs/suites/quick/der.json
+++ b/test/integration_tests/configs/suites/quick/der.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "feature-sorting-mlp-der",
-  "expected_accuracy": [0.35339, 0.3086]
+  "expected_accuracy": [0.35339999198913574, 0.3086000084877014]
 }

--- a/test/integration_tests/configs/suites/quick/er.json
+++ b/test/integration_tests/configs/suites/quick/er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-er",
-  "expected_accuracy": [0.57999, 0.367000]
+  "expected_accuracy": [0.5799999833106995, 0.367000013589859]
 }

--- a/test/integration_tests/configs/suites/quick/er.json
+++ b/test/integration_tests/configs/suites/quick/er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-er",
-  "expected_accuracy": [0.4905, 0.6715]
+  "expected_accuracy": [0.57999, 0.367000]
 }

--- a/test/integration_tests/configs/suites/quick/fine-tuning.json
+++ b/test/integration_tests/configs/suites/quick/fine-tuning.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-fine-tuning",
-  "expected_accuracy": [0.84589, 0.84589]
+  "expected_accuracy": [0.8458999991416931, 0.8458999991416931]
 }

--- a/test/integration_tests/configs/suites/quick/fine-tuning.json
+++ b/test/integration_tests/configs/suites/quick/fine-tuning.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-fine-tuning",
-  "expected_accuracy": [0.8521, 0.8521]
+  "expected_accuracy": [0.84589, 0.84589]
 }

--- a/test/integration_tests/configs/suites/quick/gdumb.json
+++ b/test/integration_tests/configs/suites/quick/gdumb.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-gdumb",
-  "expected_accuracy": [0.4165,0.9545]
+  "expected_accuracy": [0.4165, 0.9545]
 }

--- a/test/integration_tests/configs/suites/quick/gdumb.json
+++ b/test/integration_tests/configs/suites/quick/gdumb.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-gdumb",
-  "expected_accuracy": [0.4165, 0.9545]
+  "expected_accuracy": [0.4165000021457672, 0.9545000195503235]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy": [0.8639, 0.8639]
+  "expected_accuracy": [0.8639000058174133, 0.8639000058174133]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy": [0.8595, 0.8595]
+  "expected_accuracy": [0.8639, 0.8639]
 }

--- a/test/integration_tests/configs/suites/quick/offline-er.json
+++ b/test/integration_tests/configs/suites/quick/offline-er.json
@@ -5,6 +5,6 @@
     "dataset": "cifar10.json",
     "backend": "local",
     "job_name": "class-incremental-mlp-offline-er",
-    "expected_accuracy": [0.7089, 0.512],
+    "expected_accuracy": [0.7089999914169312, 0.5120000243186951],
     "loss_weight_new_data": 0.5
   }

--- a/test/integration_tests/configs/suites/quick/offline-er.json
+++ b/test/integration_tests/configs/suites/quick/offline-er.json
@@ -5,6 +5,6 @@
     "dataset": "cifar10.json",
     "backend": "local",
     "job_name": "class-incremental-mlp-offline-er",
-    "expected_accuracy": [0.6465, 0.4595],
+    "expected_accuracy": [0.7089, 0.512],
     "loss_weight_new_data": 0.5
   }

--- a/test/integration_tests/configs/suites/quick/pod-er.json
+++ b/test/integration_tests/configs/suites/quick/pod-er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "hue-shift-mlp-pod-er",
-  "expected_accuracy": [0.2000, 0.2638]
+  "expected_accuracy": [0.17059, 0.3129]
 }

--- a/test/integration_tests/configs/suites/quick/pod-er.json
+++ b/test/integration_tests/configs/suites/quick/pod-er.json
@@ -5,5 +5,5 @@
   "dataset": "cifar10.json",
   "backend": "local",
   "job_name": "hue-shift-mlp-pod-er",
-  "expected_accuracy": [0.17059, 0.3129]
+  "expected_accuracy": [0.17059999704360962, 0.31299999356269836]
 }

--- a/test/integration_tests/configs/suites/quick/super-er.json
+++ b/test/integration_tests/configs/suites/quick/super-er.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-super-er",
-  "expected_accuracy": [0.939, 0.909]
+  "expected_accuracy": [0.933, 0.91449]
 }

--- a/test/integration_tests/configs/suites/quick/super-er.json
+++ b/test/integration_tests/configs/suites/quick/super-er.json
@@ -5,5 +5,5 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-super-er",
-  "expected_accuracy": [0.933, 0.91449]
+  "expected_accuracy": [0.9330000281333923, 0.9144999980926514]
 }

--- a/test/integration_tests/run_quick_test.py
+++ b/test/integration_tests/run_quick_test.py
@@ -67,11 +67,7 @@ if __name__ == "__main__":
 
     print("Expected Accuracy:", test_config["expected_accuracy"])
     print("Actual Accuracy:", accuracies)
-    is_approximately_equal = pytest.approx(test_config["expected_accuracy"]) == accuracies
-    is_more_accurate_than_expected = pytest.approx(test_config["expected_accuracy"]) <= accuracies
-    print("Is Roughly Equal:", is_approximately_equal)
-    print("Is more accurate than expected:", is_more_accurate_than_expected)
 
     # Noticed different accuracy scores across Mac and the Linux-based hosts used in our GitHub Actions Workflows
-    # TODO see if we can return to asserting on just actual accuracy
-    assert is_approximately_equal or is_more_accurate_than_expected
+    # TODO see if we can align the Mac and Linux results
+    assert pytest.approx(test_config["expected_accuracy"]) == accuracies

--- a/test/integration_tests/run_quick_test.py
+++ b/test/integration_tests/run_quick_test.py
@@ -68,6 +68,6 @@ if __name__ == "__main__":
     print("Expected Accuracy:", test_config["expected_accuracy"])
     print("Actual Accuracy:", accuracies)
 
-    # Noticed different accuracy scores across Mac and the Linux-based hosts used in our GitHub Actions Workflows
+    # Noticed different accuracy scores across Mac and GitHub Actions Workflows (which run on Linux)
     # TODO see if we can align the Mac and Linux results
-    assert pytest.approx(test_config["expected_accuracy"]) == accuracies
+    assert pytest.approx(test_config["expected_accuracy"], rel=.01) == accuracies

--- a/test/integration_tests/run_quick_test.py
+++ b/test/integration_tests/run_quick_test.py
@@ -65,9 +65,6 @@ if __name__ == "__main__":
     else:
         accuracies = []
 
-    print("Expected Accuracy:", test_config["expected_accuracy"])
-    print("Actual Accuracy:", accuracies)
-
     # Noticed different accuracy scores across Mac and GitHub Actions Workflows (which run on Linux)
     # TODO see if we can align the Mac and Linux results
     assert pytest.approx(test_config["expected_accuracy"]) == accuracies

--- a/test/integration_tests/run_quick_test.py
+++ b/test/integration_tests/run_quick_test.py
@@ -70,4 +70,4 @@ if __name__ == "__main__":
 
     # Noticed different accuracy scores across Mac and GitHub Actions Workflows (which run on Linux)
     # TODO see if we can align the Mac and Linux results
-    assert pytest.approx(test_config["expected_accuracy"], rel=.01) == accuracies
+    assert pytest.approx(test_config["expected_accuracy"]) == accuracies

--- a/test/integration_tests/run_quick_test.py
+++ b/test/integration_tests/run_quick_test.py
@@ -65,4 +65,13 @@ if __name__ == "__main__":
     else:
         accuracies = []
 
-    assert pytest.approx(test_config["expected_accuracy"]) == accuracies
+    print("Expected Accuracy:", test_config["expected_accuracy"])
+    print("Actual Accuracy:", accuracies)
+    is_approximately_equal = pytest.approx(test_config["expected_accuracy"]) == accuracies
+    is_more_accurate_than_expected = pytest.approx(test_config["expected_accuracy"]) <= accuracies
+    print("Is Roughly Equal:", is_approximately_equal)
+    print("Is more accurate than expected:", is_more_accurate_than_expected)
+
+    # Noticed different accuracy scores across Mac and the Linux-based hosts used in our GitHub Actions Workflows
+    # TODO see if we can return to asserting on just actual accuracy
+    assert is_approximately_equal or is_more_accurate_than_expected


### PR DESCRIPTION
*Description of changes:*

Wire up the quick tests to run on GitHub Actions with each PR. 

Observed that the accuracy values differ between Mac and Linux 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
