### PR TITLE
Remove obsolete `set_transforms`  from memory buffer

### DIFF
--- a/src/renate/memory/buffer.py
+++ b/src/renate/memory/buffer.py
@@ -126,6 +126,17 @@ class DataBuffer(Dataset):
             self._add_metadata_like({key: values})
         self._metadata[key][: len(self)] = values.cpu()
 
+    def state_dict(self) -> Dict:
+        return {
+            "buffer_class_name": self.__class__.__name__,
+            "max_size": self._max_size,
+            "seed": self._seed,
+            "count": self._count,
+            "indices": self._indices,
+            "data_point_prototype": self._data_point_prototype,
+            "metadata": self._metadata,
+        }
+
     def load_state_dict(self, state_dict: Dict) -> None:
         if self.__class__.__name__ != state_dict["buffer_class_name"]:
             raise RuntimeError(

--- a/src/renate/memory/buffer.py
+++ b/src/renate/memory/buffer.py
@@ -126,24 +126,6 @@ class DataBuffer(Dataset):
             self._add_metadata_like({key: values})
         self._metadata[key][: len(self)] = values.cpu()
 
-    def set_transforms(
-        self, transform: Optional[Callable] = None, target_transform: Optional[Callable] = None
-    ) -> None:
-        """Update the transformations applied to the data."""
-        self._transform = transform
-        self._target_transform = target_transform
-
-    def state_dict(self) -> Dict:
-        return {
-            "buffer_class_name": self.__class__.__name__,
-            "max_size": self._max_size,
-            "seed": self._seed,
-            "count": self._count,
-            "indices": self._indices,
-            "data_point_prototype": self._data_point_prototype,
-            "metadata": self._metadata,
-        }
-
     def load_state_dict(self, state_dict: Dict) -> None:
         if self.__class__.__name__ != state_dict["buffer_class_name"]:
             raise RuntimeError(
@@ -173,7 +155,7 @@ class DataBuffer(Dataset):
             storage[i] = self[i][0]  # Drop metadata.
         self._datasets = [storage]
         self._indices = {i: (0, i) for i in range(len(self))}
-        self.set_transforms(*transforms)
+        self._transform, self._target_transform = transforms
 
     def load(self, source_dir: str) -> None:
         if not len(self):


### PR DESCRIPTION
This method is no longer used after the recent simplification in checkpointing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.