### PR TITLE
Upload custom files and folders with a SageMaker training Job

### DIFF
--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -392,7 +392,6 @@ def _execute_experiment_job_remotely(experiment_outputs_url: str, **job_kwargs: 
         experiment_outputs_url
     ), f"experiment_outputs_url {experiment_outputs_url} is not on S3."
     return submit_remote_job(
-        source_dir=None,
         experiment_outputs_url=experiment_outputs_url,
         optional_dependencies="benchmark",
         **job_kwargs,

--- a/src/renate/training/training.py
+++ b/src/renate/training/training.py
@@ -111,7 +111,8 @@ def run_training_job(
         input_state_url: Path to the Renate model state.
         output_state_url: Path where Renate model state will be stored.
         working_directory: Path to the working directory.
-        dependencies: (SageMaker backend only) List of files and directories moved to SageMaker.
+        dependencies: (SageMaker backend only) List of strings containing absolute or relative paths
+            to files and directories that will be uploaded as part of the SageMaker training job.
         config_file: File containing the definition of `model_fn` and `data_module_fn`.
         requirements_file: (SageMaker backend only) Path to requirements.txt containing environment
             dependencies.

--- a/src/renate/training/training.py
+++ b/src/renate/training/training.py
@@ -72,7 +72,7 @@ def run_training_job(
     input_state_url: Optional[str] = None,
     output_state_url: Optional[str] = None,
     working_directory: Optional[str] = defaults.WORKING_DIRECTORY,
-    source_dir: Optional[str] = None,
+    dependencies: Optional[List[str]] = None,
     config_file: Optional[str] = None,
     requirements_file: Optional[str] = None,
     role: Optional[str] = None,
@@ -111,7 +111,7 @@ def run_training_job(
         input_state_url: Path to the Renate model state.
         output_state_url: Path where Renate model state will be stored.
         working_directory: Path to the working directory.
-        source_dir: (SageMaker backend only) Root directory which will be moved to SageMaker.
+        dependencies: (SageMaker backend only) List of files and directories moved to SageMaker.
         config_file: File containing the definition of `model_fn` and `data_module_fn`.
         requirements_file: (SageMaker backend only) Path to requirements.txt containing environment
             dependencies.
@@ -188,7 +188,7 @@ def run_training_job(
         max_epochs=max_epochs,
         task_id=task_id,
         chunk_id=chunk_id,
-        source_dir=source_dir,
+        dependencies=dependencies or [],
         requirements_file=requirements_file,
         role=role,
         instance_type=instance_type,
@@ -625,7 +625,7 @@ def _execute_training_and_tuning_job_locally(
 
 
 def submit_remote_job(
-    source_dir: Union[str, None],
+    dependencies: List[str],
     role: str,
     instance_type: str,
     instance_count: int,
@@ -641,12 +641,11 @@ def submit_remote_job(
     job_timestamp = defaults.current_timestamp()
     job_name = f"{job_name}-{job_timestamp}"
     tmp_dir = tempfile.mkdtemp()
-    dependencies = _prepare_remote_job(
+    dependencies += _prepare_remote_job(
         tmp_dir=tmp_dir, optional_dependencies=optional_dependencies, **job_kwargs
     )
     PyTorch(
         entry_point=tuning_script,
-        source_dir=None if source_dir is None else str(source_dir),
         instance_type=instance_type,
         instance_count=instance_count,
         py_version=defaults.PYTHON_VERSION,


### PR DESCRIPTION
- Removed source_dir: this requires the entry point to be within source_dir which is not the case for us
- Added dependencies argument: alternate way to upload custom files and folders


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
