### PR TITLE
Flag to remove intermediate tasks' states

### DIFF
--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -384,6 +384,10 @@ def _execute_experiment_job_locally(
     cumulative_metrics = create_cumulative_metrics("classification")
     df = cumulative_metrics_summary(results, cumulative_metrics, num_updates - 1)
     save_pandas_df_to_csv(df, defaults.metric_summary_file(logs_url))
+    if not retain_intermediate_state:
+        move_to_uri(
+            defaults.hpo_file(working_directory), defaults.logs_folder(experiment_outputs_url)
+        )
     logger.info("### Cumulative results: ###")
     logger.info(df)
 

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -149,6 +149,7 @@ def execute_experiment_job(
     job_name: str = defaults.JOB_NAME,
     strategy: str = defaults.DISTRIBUTED_STRATEGY,
     precision: str = defaults.PRECISION,
+    retain_intermediate_state: bool = defaults.RETAIN_INTERMEDIATE_STATE,
 ) -> None:
     """Executes the experiment job.
 
@@ -179,6 +180,10 @@ def execute_experiment_job(
         deterministic_trainer: When true the Trainer adopts a deterministic behaviour also on GPU.
             In this function this parameter is set to True by default.
         job_name: Name of the experiment job.
+        strategy: String denoting lightning distributed strategy.
+        precision: String for which precision to use.
+        retain_intermediate_state: Flag to retain intermediate models and buffer states.
+            This is useful when training with large datasets that might cause storage issues.
     """
     assert (
         mode in defaults.SUPPORTED_TUNING_MODE
@@ -206,6 +211,7 @@ def execute_experiment_job(
             seed=seed,
             strategy=strategy,
             precision=precision,
+            retain_intermediate_state=retain_intermediate_state,
         )
     _execute_experiment_job_remotely(
         job_name=job_name,
@@ -232,6 +238,7 @@ def execute_experiment_job(
         instance_max_time=instance_max_time,
         strategy=strategy,
         precision=precision,
+        retain_intermediate_state=retain_intermediate_state,
     )
 
 
@@ -254,6 +261,7 @@ def _execute_experiment_job_locally(
     deterministic_trainer: bool,
     strategy: str,
     precision: str,
+    retain_intermediate_state: bool,
 ) -> None:
     """Runs an experiment, combining hyperparameter tuning and model for multiple updates.
 
@@ -347,7 +355,8 @@ def _execute_experiment_job_locally(
             deterministic_trainer=deterministic_trainer,
         )
         move_to_uri(output_state_url, input_state_url)
-        copy_to_uri(input_state_url, update_url)
+        if retain_intermediate_state:
+            copy_to_uri(input_state_url, update_url)
         model = get_model(
             config_module,
             model_state_url=model_url,

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -386,7 +386,7 @@ def _execute_experiment_job_locally(
     save_pandas_df_to_csv(df, defaults.metric_summary_file(logs_url))
     if not retain_intermediate_state:
         move_to_uri(
-            defaults.hpo_file(working_directory), defaults.logs_folder(experiment_outputs_url)
+            defaults.hpo_file(input_state_url), defaults.logs_folder(experiment_outputs_url)
         )
     logger.info("### Cumulative results: ###")
     logger.info(df)

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -182,8 +182,9 @@ def execute_experiment_job(
         job_name: Name of the experiment job.
         strategy: String denoting lightning distributed strategy.
         precision: String for which precision to use.
-        retain_intermediate_state: Flag to retain intermediate models and buffer states.
-            This is useful when training with large datasets that might cause storage issues.
+        retain_intermediate_state: Flag to retain intermediate models and buffer states after each
+            task update. This is useful when training with large datasets that might cause storage
+            issues.
     """
     assert (
         mode in defaults.SUPPORTED_TUNING_MODE

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -182,7 +182,7 @@ def execute_experiment_job(
         job_name: Name of the experiment job.
         strategy: String denoting lightning distributed strategy.
         precision: String for which precision to use.
-        retain_intermediate_state: Flag to retain intermediate models and buffer states after each
+        retain_intermediate_state: Flag to retain models and buffer states after each
             task update. This is useful when training with large datasets that might cause storage
             issues.
     """

--- a/src/renate/defaults.py
+++ b/src/renate/defaults.py
@@ -57,6 +57,7 @@ JOB_KWARGS_FILE = "job_kwargs.json"
 JOB_NAME = "renate"
 SUPPORTED_TUNING_MODE = ["min", "max"]
 SUPPORTED_TUNING_MODE_TYPE = Literal["min", "max"]
+RETAIN_INTERMEDIATE_STATE = True
 
 SUPPORTED_BACKEND = ["local", "sagemaker"]
 SUPPORTED_BACKEND_TYPE = Literal["local", "sagemaker"]


### PR DESCRIPTION
Large datasets' buffers can be too big and result in storage issues (noticed while training CLEAR). This flag eliminates backing up intermediate results and overwrites the same folder/files in each update. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
