### PR TITLE
Fix Small Bug in Benchmarking Script and Add LR Scheduler to Experiment Config

### DIFF
--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -1,9 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Optional, Tuple, Union
+from functools import partial
+from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 import wild_time_data
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import StepLR, _LRScheduler
 from torchvision.transforms import transforms
 from transformers import AutoTokenizer
 
@@ -335,3 +338,23 @@ def test_transform(dataset_name: str) -> Optional[transforms.Normalize]:
             ]
         )
     raise ValueError(f"Unknown dataset `{dataset_name}`.")
+
+
+def lr_scheduler_fn(
+    learning_rate_scheduler: Optional[str] = None,
+    learning_rate_scheduler_step_size: int = 30,
+    learning_rate_scheduler_gamma: float = 0.1,
+    learning_rate_scheduler_interval: str = "epoch",
+) -> Tuple[Optional[Callable[[Optimizer], _LRScheduler]], str]:
+    if learning_rate_scheduler == "StepLR":
+        return (
+            partial(
+                StepLR,
+                step_size=learning_rate_scheduler_step_size,
+                gamma=learning_rate_scheduler_gamma,
+            ),
+            learning_rate_scheduler_interval,
+        )
+    elif learning_rate_scheduler is None:
+        return None, learning_rate_scheduler_interval
+    raise ValueError(f"Unknown scheduler: {learning_rate_scheduler}.")

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -133,6 +133,7 @@ def execute_experiment_job(
     num_updates: int,
     working_directory: Optional[str] = defaults.WORKING_DIRECTORY,
     requirements_file: Optional[str] = None,
+    dependencies: Optional[List[str]] = None,
     role: Optional[str] = None,
     instance_type: str = defaults.INSTANCE_TYPE,
     instance_count: int = defaults.INSTANCE_COUNT,
@@ -165,6 +166,8 @@ def execute_experiment_job(
         num_updates: Number of updates of the experiment job.
         working_directory: Path to the working directory.
         requirements_file: Path to the requirements file.
+        dependencies: (SageMaker backend only) List of strings containing absolute or relative paths
+            to files and directories that will be uploaded as part of the SageMaker training job.
         role: Role of the experiment job.
         instance_type: Instance type of the experiment job.
         instance_count: Instance count of the experiment job.
@@ -222,6 +225,7 @@ def execute_experiment_job(
         metric=metric,
         num_updates=num_updates,
         working_directory=working_directory,
+        dependencies=dependencies or [],
         config_space=config_space,
         max_time=max_time,
         max_num_trials_started=max_num_trials_started,

--- a/src/renate/benchmark/experimentation.py
+++ b/src/renate/benchmark/experimentation.py
@@ -389,7 +389,7 @@ def _execute_experiment_job_locally(
     df = cumulative_metrics_summary(results, cumulative_metrics, num_updates - 1)
     save_pandas_df_to_csv(df, defaults.metric_summary_file(logs_url))
     if not retain_intermediate_state:
-        move_to_uri(
+        shutil.move(
             defaults.hpo_file(input_state_url), defaults.logs_folder(experiment_outputs_url)
         )
     logger.info("### Cumulative results: ###")


### PR DESCRIPTION
- Benchmarking script fails if no intermediate states are used since it tries to move a file with a function that expects a folder
- Add LR scheduler to replicate CLEAR results


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
