### PR TITLE
Describe Installation of Dependencies for Benchmarking

### DIFF
--- a/doc/benchmarking/index.rst
+++ b/doc/benchmarking/index.rst
@@ -14,6 +14,13 @@ At the core of this feature is the function :py:func:`~renate.benchmark.experime
 For the reader familiar with the function :py:func:`~renate.training.training.run_training_job`, the use will be very
 intuitive.
 
+Renate's benchmarking functionality may require additional dependencies.
+Please install them via
+
+.. code-block:: bash
+
+    pip install Renate[benchmark]
+
 In the following chapters, we will discuss how this interface can be used to experiment on
 :doc:`Renate benchmarks <renate_benchmarks>` as well as
 :doc:`custom benchmarks <custom_benchmarks>`.

--- a/doc/getting_started/install.rst
+++ b/doc/getting_started/install.rst
@@ -13,7 +13,18 @@ If you want to use additional methods that require the Avalanche library, please
 
     pip install Renate[avalanche]
 
-For Renate contributors we recommend using ``dev``.
+If you want to use Renate for :doc:`benchmarking <../benchmarking/index>`, please use
+
+.. code-block:: bash
+
+    pip install Renate[benchmark]
+
+Renate contributors should use
+
+.. code-block:: bash
+
+    pip install Renate[dev]
+
 This will install further dependencies which are required for code formatting and unit testing.
 
 Alternatively, if you want to access the code directly (e.g., for developing and running new methods)


### PR DESCRIPTION
In order to run benchmarking, Renate[benchmark] must be installed. This hasn't been described so far.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
