### PR TITLE
Upgrade wild-time-data package

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,4 +9,4 @@ sphinx-paramlinks==0.5.4
 
 # Temporarily added
 avalanche_lib==0.3.1
-wild-time-data==0.1.0
+wild-time-data==0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,12 @@ avalanche = [
     "torch>=1.10.0, <1.12.2",
 ]
 benchmark = [
-    "wild-time-data==0.1.0",
+    "wild-time-data==0.1.1",
 ]
 dev = [
     "black==23.3.0",
     "avalanche_lib==0.3.1",
-    "wild-time-data==0.1.0",
+    "wild-time-data==0.1.1",
     "torch>=1.10.0, <1.12.2",
     # PyTest Dependencies
     "pytest==7.3.1",


### PR DESCRIPTION
Latest version of that dependency allows Python versions larger than 3.10, e.g. 3.10.1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
