### PR TITLE
Fix CLS-ER Loss

### DIFF
--- a/src/renate/updaters/learner_components/losses.py
+++ b/src/renate/updaters/learner_components/losses.py
@@ -365,7 +365,7 @@ class WeightedCLSLossComponent(WeightedLossComponent):
         (inputs_memory, targets_memory), _ = batch_memory
         with torch.no_grad():
             outputs_plastic = self._plastic_model(inputs_memory)
-            outputs_stable = self._plastic_model(inputs_memory)
+            outputs_stable = self._stable_model(inputs_memory)
             probs_plastic = F.softmax(outputs_plastic, dim=-1)
             probs_stable = F.softmax(outputs_stable, dim=-1)
             label_mask = F.one_hot(targets_memory, num_classes=outputs_stable.shape[-1]) > 0

--- a/test/integration_tests/configs/suites/quick/cls-er.json
+++ b/test/integration_tests/configs/suites/quick/cls-er.json
@@ -6,5 +6,5 @@
   "backend": "local",
   "job_name": "class-incremental-mlp-cls-er",
   "expected_accuracy_linux": [[0.9858155846595764, 0.9740450382232666]],
-  "expected_accuracy_darwin": [[0.9858155846595764, 0.9755141735076904]]
+  "expected_accuracy_darwin": [[0.9834515452384949, 0.9740450382232666]]
 }


### PR DESCRIPTION
CLS loss was not computed based on the stable model but twice on the plastic model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
