### PR TITLE
Support Use of Joint and GDumb with Pre-Trained Models

### DIFF
--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -454,11 +454,22 @@ def _add_base_experience_replay_arguments(arguments: Dict[str, Dict[str, Any]]) 
 def _add_gdumb_arguments(arguments: Dict[str, Dict[str, Any]]) -> None:
     """A helper function that adds GDumb arguments."""
     _add_replay_learner_arguments(arguments)
+    _add_joint_arguments(arguments)
 
 
 def _add_joint_arguments(arguments: Dict[str, Dict[str, Any]]) -> None:
     """A helper function that adds Joint Learner arguments."""
-    pass
+    arguments.update(
+        {
+            "reset": {
+                "type": str,
+                "default": "True",
+                "choices": ["True", "False"],
+                "help": "Resets the model before the update. Default: True",
+                "true_type": bool,
+            },
+        }
+    )
 
 
 def _add_finetuning_arguments(arguments: Dict[str, Dict[str, Any]]) -> None:

--- a/src/renate/cli/run_training.py
+++ b/src/renate/cli/run_training.py
@@ -122,7 +122,7 @@ class ModelUpdaterCLI:
         )
         model = get_model(
             config_module,
-            model_state_url=self._current_model_file,
+            model_state_url=None if getattr(args, "reset", False) else self._current_model_file,
             **get_function_kwargs(args=args, function_args=function_args["model_fn"]),
         )
         loss_fn = get_loss_fn(

--- a/src/renate/updaters/experimental/gdumb.py
+++ b/src/renate/updaters/experimental/gdumb.py
@@ -17,7 +17,6 @@ from renate.models import RenateModule
 from renate.types import NestedTensors
 from renate.updaters.learner import ReplayLearner
 from renate.updaters.model_updater import SingleTrainingLoopUpdater
-from renate.utils.pytorch import reinitialize_model_parameters
 
 
 class GDumbLearner(ReplayLearner):
@@ -79,7 +78,6 @@ class GDumbLearner(ReplayLearner):
             task_id=task_id,
         )
         self._memory_buffer.update(train_dataset)
-        reinitialize_model_parameters(self._model)
 
     def train_dataloader(self) -> DataLoader:
         return DataLoader(

--- a/src/renate/updaters/experimental/joint.py
+++ b/src/renate/updaters/experimental/joint.py
@@ -18,7 +18,6 @@ from renate.models import RenateModule
 from renate.types import NestedTensors
 from renate.updaters.learner import Learner
 from renate.updaters.model_updater import SingleTrainingLoopUpdater
-from renate.utils.pytorch import reinitialize_model_parameters
 
 
 class JointLearner(Learner):
@@ -72,7 +71,6 @@ class JointLearner(Learner):
             task_id=task_id,
         )
         self._memory_buffer.update(train_dataset)
-        reinitialize_model_parameters(self._model)
 
     def train_dataloader(self) -> DataLoader:
         return DataLoader(

--- a/test/integration_tests/configs/suites/quick/gdumb.json
+++ b/test/integration_tests/configs/suites/quick/gdumb.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-gdumb",
-  "expected_accuracy_linux": [[0.8364999890327454, 0.8634999990463257]],
-  "expected_accuracy_darwin": [[0.8364999890327454, 0.8634999990463257]]
+  "expected_accuracy_linux": [[0.43050000071525574, 0.8069999814033508]],
+  "expected_accuracy_darwin": [[0.43050000071525574, 0.8069999814033508]]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy_linux": [[0.8495000004768372, 0.8495000004768372], [0.8427000045776367, 0.8427000045776367]],
+  "expected_accuracy_linux": [[0.8496000170707703, 0.8496000170707703], [0.8427000045776367, 0.8427000045776367]],
   "expected_accuracy_darwin": [[0.8585000038146973, 0.8585000038146973]]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -6,5 +6,5 @@
   "backend": "local",
   "job_name": "iid-mlp-joint",
   "expected_accuracy_linux": [[0.8495000004768372, 0.8495000004768372], [0.8427000045776367, 0.8427000045776367]],
-  "expected_accuracy_darwin": [[0.84170001745224, 0.84170001745224]]
+  "expected_accuracy_darwin": [[0.8585000038146973, 0.8585000038146973]]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy_linux": [[0.8496000170707703, 0.8496000170707703], [0.8427000045776367, 0.8427000045776367]],
+  "expected_accuracy_linux": [[0.8496000170707703, 0.8496000170707703], [0.8550000190734863, 0.8550000190734863]],
   "expected_accuracy_darwin": [[0.8585000038146973, 0.8585000038146973]]
 }

--- a/test/renate/updaters/experimental/test_joint.py
+++ b/test/renate/updaters/experimental/test_joint.py
@@ -1,28 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import copy
 
 import pytest
-import torch
 
 import renate.defaults as defaults
 from renate.updaters.experimental.joint import JointLearner
 
 
-def get_model_and_dataset():
-    model = pytest.helpers.get_renate_module_mlp(
-        num_outputs=10, num_inputs=10, hidden_size=32, num_hidden_layers=3
-    )
-    dataset = torch.utils.data.TensorDataset(
-        torch.rand((100, 10)),
-        torch.randint(10, (100,)),
-    )
-    return model, dataset
-
-
 def test_joint_learner_memory_append():
     """This test checks that the memory buffer is updated correctly."""
-    model, dataset = get_model_and_dataset()
+    model, dataset, _ = pytest.helpers.get_renate_module_mlp_and_data(
+        num_inputs=10,
+        num_outputs=10,
+        num_hidden_layers=3,
+        hidden_size=32,
+        train_num_samples=100,
+        test_num_samples=100,
+    )
     dataset_len = len(dataset)
     model_updater = pytest.helpers.get_simple_updater(
         model=model,

--- a/test/renate/updaters/experimental/test_joint.py
+++ b/test/renate/updaters/experimental/test_joint.py
@@ -35,23 +35,3 @@ def test_joint_learner_memory_append():
     assert len(model_updater._learner._memory_buffer) == dataset_len
     model_updater.update(train_dataset=dataset, task_id=defaults.TASK_ID)
     assert len(model_updater._learner._memory_buffer) == 2 * dataset_len
-
-
-def test_joint_learner_model_reset():
-    """This test checks that the model is reinitialized correctly before an update."""
-    model, dataset = get_model_and_dataset()
-    model_updater = pytest.helpers.get_simple_updater(
-        model=model,
-        partial_optimizer=pytest.helpers.get_partial_optimizer(lr=0.0),
-        learner_class=JointLearner,
-        learner_kwargs={},
-        max_epochs=1,
-    )
-    model = model_updater.update(train_dataset=dataset, task_id=defaults.TASK_ID)
-    model_copy = copy.deepcopy(model)
-    model = model_updater.update(train_dataset=dataset, task_id=defaults.TASK_ID)
-    for (name, param), (name_copy, param_copy) in zip(
-        model.named_parameters(), model_copy.named_parameters()
-    ):
-        assert name == name_copy
-        assert not torch.allclose(param, param_copy)


### PR DESCRIPTION
Joint and Gdumb reset the models `on_model_update_start`. This results in a non-desired behavior when working with pre-trained models.
There is also no option to *not* reset the model at all.

The change introduces a new flag `reset` which allows to control whether the model will be reset. Furthermore, in case of a reset, the pre-trained model will be reloaded instead of using an untrained model.

The integration tests are expected to break for Joint and GDumb due to a different initialization of the model. Before, the workflow was creating the model and resetting it. Now, it only creates the model without reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
