### PR TITLE
Wild Time Benchmarks and Small Memory Hack

### DIFF
--- a/benchmarks/experiment_configs/datasets/arxiv.json
+++ b/benchmarks/experiment_configs/datasets/arxiv.json
@@ -1,0 +1,6 @@
+{
+  "dataset_name": "arxiv",
+  "src_bucket": "my_bucket",
+  "src_object_name": "dataset/wildtime/arxiv.hdf5",
+  "num_outputs": 172
+}

--- a/benchmarks/experiment_configs/datasets/fmow.json
+++ b/benchmarks/experiment_configs/datasets/fmow.json
@@ -1,9 +1,7 @@
 {
   "dataset_name": "fmow",
-  "src_bucket": "mnemosyne-team-bucket",
+  "src_bucket": "my_bucket",
   "src_object_name": "dataset/wildtime/fmow.hdf5",
   "num_inputs": 150528,
-  "num_outputs": 62,
-  "num_tasks": 16,
-  "max_epochs": 50
+  "num_outputs": 62
 }

--- a/benchmarks/experiment_configs/datasets/huffpost.json
+++ b/benchmarks/experiment_configs/datasets/huffpost.json
@@ -1,9 +1,6 @@
 {
   "dataset_name": "huffpost",
-  "src_bucket": "mnemosyne-team-bucket",
+  "src_bucket": "my_bucket",
   "src_object_name": "dataset/wildtime/huffpost.hdf5",
-  "num_inputs": 0,
-  "num_outputs": 11,
-  "num_tasks": 7,
-  "max_epochs": 5
+  "num_outputs": 11
 }

--- a/benchmarks/experiment_configs/fine-tuning-arxiv.json
+++ b/benchmarks/experiment_configs/fine-tuning-arxiv.json
@@ -1,0 +1,6 @@
+{
+  "scenario": "arxiv-16updates.json",
+  "model": "bert.json",
+  "updater": "fine-tuning-arxiv.json",
+  "dataset": "arxiv.json"
+}

--- a/benchmarks/experiment_configs/fine-tuning-fmow.json
+++ b/benchmarks/experiment_configs/fine-tuning-fmow.json
@@ -1,5 +1,5 @@
 {
-  "scenario": "wild-time.json",
+  "scenario": "fmow-16updates.json",
   "model": "resnet18.json",
   "updater": "fine-tuning-fmow.json",
   "dataset": "fmow.json"

--- a/benchmarks/experiment_configs/fine-tuning-huffpost.json
+++ b/benchmarks/experiment_configs/fine-tuning-huffpost.json
@@ -1,5 +1,5 @@
 {
-  "scenario": "wild-time.json",
+  "scenario": "huffpost-7updates.json",
   "model": "bert.json",
   "updater": "fine-tuning-huffpost.json",
   "dataset": "huffpost.json"

--- a/benchmarks/experiment_configs/joint-arxiv.json
+++ b/benchmarks/experiment_configs/joint-arxiv.json
@@ -1,0 +1,6 @@
+{
+  "scenario": "arxiv-16updates.json",
+  "model": "bert.json",
+  "updater": "joint-arxiv.json",
+  "dataset": "arxiv.json"
+}

--- a/benchmarks/experiment_configs/joint-fmow.json
+++ b/benchmarks/experiment_configs/joint-fmow.json
@@ -1,0 +1,6 @@
+{
+  "scenario": "fmow-16updates.json",
+  "model": "resnet18.json",
+  "updater": "joint-fmow.json",
+  "dataset": "fmow.json"
+}

--- a/benchmarks/experiment_configs/joint-huffpost.json
+++ b/benchmarks/experiment_configs/joint-huffpost.json
@@ -1,0 +1,6 @@
+{
+  "scenario": "huffpost-7updates.json",
+  "model": "bert.json",
+  "updater": "joint-huffpost.json",
+  "dataset": "huffpost.json"
+}

--- a/benchmarks/experiment_configs/scenarios/arxiv-16updates.json
+++ b/benchmarks/experiment_configs/scenarios/arxiv-16updates.json
@@ -1,0 +1,9 @@
+{
+  "val_size": 0.1,
+  "scenario_name": "DataIncrementalScenario",
+  "num_tasks": 16,
+  "max_epochs": 2,
+  "optimizer": "AdamW",
+  "learning_rate": 0.00002,
+  "weight_decay": 0.01
+}

--- a/benchmarks/experiment_configs/scenarios/clear10-10updates.json
+++ b/benchmarks/experiment_configs/scenarios/clear10-10updates.json
@@ -7,7 +7,6 @@
   "learning_rate": 0.01,
   "momentum": 0.9,
   "weight_decay": 1e-5,
-  "batch_size": 256,
   "learning_rate_scheduler": "StepLR",
   "learning_rate_scheduler_step_size": 30,
   "learning_rate_scheduler_gamma": 0.1,

--- a/benchmarks/experiment_configs/scenarios/clear100-11updates.json
+++ b/benchmarks/experiment_configs/scenarios/clear100-11updates.json
@@ -7,7 +7,6 @@
   "learning_rate": 0.01,
   "momentum": 0.9,
   "weight_decay": 1e-5,
-  "batch_size": 256,
   "learning_rate_scheduler": "StepLR",
   "learning_rate_scheduler_step_size": 30,
   "learning_rate_scheduler_gamma": 0.1,

--- a/benchmarks/experiment_configs/scenarios/fmow-16updates.json
+++ b/benchmarks/experiment_configs/scenarios/fmow-16updates.json
@@ -1,0 +1,14 @@
+{
+  "val_size": 0.1,
+  "scenario_name": "DataIncrementalScenario",
+  "num_tasks": 16,
+  "max_epochs": 50,
+  "optimizer": "SGD",
+  "learning_rate": 0.1,
+  "learning_rate_scheduler": "CosineAnnealingLR",
+  "learning_rate_scheduler_t_max": 50,
+  "learning_rate_scheduler_eta_min": 0.0001,
+  "learning_rate_scheduler_interval": "step",
+  "momentum": 0.0,
+  "weight_decay": 0.0
+}

--- a/benchmarks/experiment_configs/scenarios/huffpost-7updates.json
+++ b/benchmarks/experiment_configs/scenarios/huffpost-7updates.json
@@ -1,0 +1,9 @@
+{
+  "val_size": 0.1,
+  "scenario_name": "DataIncrementalScenario",
+  "num_tasks": 7,
+  "max_epochs": 4,
+  "optimizer": "AdamW",
+  "learning_rate": 0.00002,
+  "weight_decay": 0.01
+}

--- a/benchmarks/experiment_configs/scenarios/wild-time.json
+++ b/benchmarks/experiment_configs/scenarios/wild-time.json
@@ -1,4 +1,0 @@
-{
-  "val_size": 0.1,
-  "scenario_name": "DataIncrementalScenario"
-}

--- a/benchmarks/experiment_configs/updaters/fine-tuning-arxiv.json
+++ b/benchmarks/experiment_configs/updaters/fine-tuning-arxiv.json
@@ -1,0 +1,4 @@
+{
+    "updater": "FineTuning",
+    "batch_size": 64
+}

--- a/benchmarks/experiment_configs/updaters/fine-tuning-fmow.json
+++ b/benchmarks/experiment_configs/updaters/fine-tuning-fmow.json
@@ -1,11 +1,4 @@
 {
     "updater": "FineTuning",
-    "optimizer": "SGD",
-    "learning_rate": 0.03,
-    "learning_rate_scheduler": "CosineAnnealingLR",
-    "learning_rate_scheduler_t_max": 50,
-    "learning_rate_scheduler_eta_min": 0.0001,
-    "learning_rate_scheduler_interval": "step",
-    "momentum": 0.0,
-    "weight_decay": 0.0
+    "batch_size": 64
 }

--- a/benchmarks/experiment_configs/updaters/fine-tuning-huffpost.json
+++ b/benchmarks/experiment_configs/updaters/fine-tuning-huffpost.json
@@ -1,8 +1,4 @@
 {
     "updater": "FineTuning",
-    "optimizer": "Adam",
-    "learning_rate": 0.0001,
-    "momentum": 0.9,
-    "weight_decay": 0.0,
-    "batch_size": 64
+    "batch_size": 32
 }

--- a/benchmarks/experiment_configs/updaters/joint-arxiv.json
+++ b/benchmarks/experiment_configs/updaters/joint-arxiv.json
@@ -1,0 +1,4 @@
+{
+    "updater": "Joint",
+    "batch_size": 64
+}

--- a/benchmarks/experiment_configs/updaters/joint-fmow.json
+++ b/benchmarks/experiment_configs/updaters/joint-fmow.json
@@ -1,0 +1,4 @@
+{
+    "updater": "Joint",
+    "batch_size": 64
+}

--- a/benchmarks/experiment_configs/updaters/joint-huffpost.json
+++ b/benchmarks/experiment_configs/updaters/joint-huffpost.json
@@ -1,0 +1,4 @@
+{
+    "updater": "Joint",
+    "batch_size": 32
+}

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -94,7 +94,6 @@ if __name__ == "__main__":
             working_directory = str(Path("tmp") / "renate_working_dir")
         else:
             AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity().get("Account")
-
             experiment_outputs_url = (
                 f"s3://sagemaker-us-west-2-{AWS_ACCOUNT_ID}/renate-domain-incremental/"
                 f"{args.job_name}/{seed}"

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -91,10 +91,10 @@ if __name__ == "__main__":
             experiment_outputs_url = (
                 Path("tmp") / "renate-integration-tests" / args.job_name / str(seed)
             )
-            role = None
             working_directory = str(Path("tmp") / "renate_working_dir")
         else:
             AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity().get("Account")
+
             experiment_outputs_url = (
                 f"s3://sagemaker-us-west-2-{AWS_ACCOUNT_ID}/renate-domain-incremental/"
                 f"{args.job_name}/{seed}"

--- a/src/renate/benchmark/datasets/vision_datasets.py
+++ b/src/renate/benchmark/datasets/vision_datasets.py
@@ -173,12 +173,14 @@ class TorchVisionDataModule(RenateDataModule):
         train_data = cls(
             self._data_path,
             train=True,
+            transform=transforms.ToTensor(),
             target_transform=transforms.Lambda(to_long),
         )
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         self._test_data = cls(
             self._data_path,
             train=False,
+            transform=transforms.ToTensor(),
             target_transform=transforms.Lambda(to_long),
         )
 

--- a/src/renate/benchmark/datasets/vision_datasets.py
+++ b/src/renate/benchmark/datasets/vision_datasets.py
@@ -68,10 +68,10 @@ class TinyImageNetDataModule(RenateDataModule):
     def setup(self) -> None:
         """Set up train, test and val datasets."""
         X, y = self._preprocess_tiny_imagenet(train=True)
-        train_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        train_data = ImageDataset(X, y)
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         X, y = self._preprocess_tiny_imagenet(train=False)
-        self._test_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        self._test_data = ImageDataset(X, y)
 
     def _preprocess_tiny_imagenet(self, train: bool) -> Tuple[List[str], List[int]]:
         """A helper function to preprocess the TinyImageNet dataset."""
@@ -173,14 +173,12 @@ class TorchVisionDataModule(RenateDataModule):
         train_data = cls(
             self._data_path,
             train=True,
-            transform=transforms.ToTensor(),
             target_transform=transforms.Lambda(to_long),
         )
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         self._test_data = cls(
             self._data_path,
             train=False,
-            transform=transforms.ToTensor(),
             target_transform=transforms.Lambda(to_long),
         )
 
@@ -259,10 +257,10 @@ class CLEARDataModule(DataIncrementalDataModule):
         """Set up train, test and val datasets."""
         time_step = self.data_id + 1 if self._dataset_name == "clear10" else self.data_id
         X, y = self._get_filepaths_and_labels(train=True, time_step=time_step)
-        train_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        train_data = ImageDataset(X, y)
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         X, y = self._get_filepaths_and_labels(train=False, time_step=time_step)
-        self._test_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        self._test_data = ImageDataset(X, y)
 
     def _get_filepaths_and_labels(self, train: bool, time_step: int) -> Tuple[List[str], List[int]]:
         """Extracts all the filepaths and labels for a given chunk id and split."""
@@ -384,10 +382,10 @@ class DomainNetDataModule(DataIncrementalDataModule):
     def setup(self) -> None:
         """Set up train, test and val datasets."""
         X, y = self._get_filepaths_and_labels("train")
-        train_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        train_data = ImageDataset(X, y)
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         X, y = self._get_filepaths_and_labels("test")
-        self._test_data = ImageDataset(X, y, transform=transforms.ToTensor())
+        self._test_data = ImageDataset(X, y)
 
     def _get_filepaths_and_labels(self, split: str) -> Tuple[List[str], List[int]]:
         """Extracts all the filepaths and labels for a given split."""

--- a/src/renate/benchmark/datasets/wild_time_data.py
+++ b/src/renate/benchmark/datasets/wild_time_data.py
@@ -90,6 +90,7 @@ class WildTimeDataModule(DataIncrementalDataModule):
             "time_step": available_time_steps(self._dataset_name)[self.data_id],
             "data_dir": self._data_path,
             "in_memory": self._dataset_name != "fmow",
+            "transform": None if self._dataset_name != "fmow" else lambda x: x,
         }
         if self._tokenizer:
             kwargs["transform"] = lambda x: self._tokenizer(x, **(self._tokenizer_kwargs or {}))

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -5,11 +5,12 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import wild_time_data
-from torch.optim import Optimizer
+from torch.optim import AdamW, Optimizer
 from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR, _LRScheduler
 from torchmetrics.classification import MulticlassAccuracy
 from torchvision.transforms import transforms
 from transformers import AutoTokenizer
+from wild_time_data.datasets import FMoW
 
 from renate.benchmark.datasets.nlp_datasets import HuggingFaceTextDataModule
 from renate.benchmark.datasets.vision_datasets import (
@@ -317,6 +318,8 @@ def _get_normalize_transform(dataset_name):
 
 def train_transform(dataset_name: str) -> Optional[Callable]:
     """Returns a transform function to be used in the training."""
+    if dataset_name == "fmow":
+        return FMoW.default_transform
     if dataset_name in [
         "MNIST",
         "FashionMNIST",
@@ -333,6 +336,7 @@ def train_transform(dataset_name: str) -> Optional[Callable]:
     if dataset_name in ["CLEAR10", "CLEAR100", "DomainNet"]:
         return transforms.Compose(
             [
+                transforms.ToTensor(),
                 transforms.Resize(
                     224, interpolation=transforms.InterpolationMode.BILINEAR, antialias=True
                 ),
@@ -345,6 +349,8 @@ def train_transform(dataset_name: str) -> Optional[Callable]:
 
 def test_transform(dataset_name: str) -> Optional[Callable]:
     """Returns a transform function to be used for validation or testing."""
+    if dataset_name == "fmow":
+        return FMoW.default_transform
     if dataset_name in [
         "MNIST",
         "FashionMNIST",
@@ -355,6 +361,7 @@ def test_transform(dataset_name: str) -> Optional[Callable]:
     if dataset_name in ["CLEAR10", "CLEAR100", "DomainNet"]:
         return transforms.Compose(
             [
+                transforms.ToTensor(),
                 transforms.Resize(
                     224, interpolation=transforms.InterpolationMode.BILINEAR, antialias=True
                 ),
@@ -398,3 +405,13 @@ def lr_scheduler_fn(
 
 def metrics_fn(num_outputs: int) -> Dict:
     return {"accuracy": MulticlassAccuracy(num_classes=num_outputs, average="micro")}
+
+
+def optimizer_fn(
+    optimizer: str,
+    learning_rate: float,
+    weight_decay: float,
+    momentum: float = 0.0,  # TODO: fix problem that occurs when removing this
+) -> Callable:
+    if optimizer == "AdamW":
+        return partial(AdamW, lr=learning_rate, weight_decay=weight_decay)

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -10,6 +10,7 @@ from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR, _LRScheduler
 from torchmetrics.classification import MulticlassAccuracy
 from torchvision.transforms import transforms
 from transformers import AutoTokenizer
+from wild_time_data import default_transform
 from wild_time_data.datasets import FMoW
 
 from renate.benchmark.datasets.nlp_datasets import HuggingFaceTextDataModule
@@ -319,7 +320,7 @@ def _get_normalize_transform(dataset_name):
 def train_transform(dataset_name: str) -> Optional[Callable]:
     """Returns a transform function to be used in the training."""
     if dataset_name == "fmow":
-        return FMoW.default_transform
+        return default_transform(dataset_name)
     if dataset_name in [
         "MNIST",
         "FashionMNIST",

--- a/src/renate/benchmark/models/vision_transformer.py
+++ b/src/renate/benchmark/models/vision_transformer.py
@@ -50,7 +50,7 @@ class VisionTransformer(RenateBenchmarkingModule):
     arXiv preprint arXiv:2010.11929 (2020).
 
     Args:
-        pretrained_name: A string that denotes which pretrained model from the HF hub to use.
+        pretrained_model_name_or_path: A string that denotes which pretrained model from the HF hub to use.
             If provided, it overrides other arguments about architecture.
         image_size: Size of the input image.
         patch_size: Size of the patches.

--- a/src/renate/benchmark/models/vision_transformer.py
+++ b/src/renate/benchmark/models/vision_transformer.py
@@ -50,8 +50,8 @@ class VisionTransformer(RenateBenchmarkingModule):
     arXiv preprint arXiv:2010.11929 (2020).
 
     Args:
-        pretrained_model_name_or_path: A string that denotes which pretrained model from the HF hub to use.
-            If provided, it overrides other arguments about architecture.
+        pretrained_model_name_or_path: A string that denotes which pretrained model from the HF hub
+            to use. If provided, it overrides other arguments about architecture.
         image_size: Size of the input image.
         patch_size: Size of the patches.
         num_layers: Number of Encoder layers.


### PR DESCRIPTION
Add files required to run experimentation with Wild Time Benchmarks.

Save PIL images rather than tensors in buffers to keep memory space lower.

Found bug: `optimizer_fn` doesn't work as intended. If it exists, it must return an optimizer. We would like that it can exist but it either returns an optimizer or `None`. Currently "fixed" by adding all arguments expected for an optimizer to the function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
