### PR TITLE
Clean Up Learner Checkpoint and Fix Model Loading

### DIFF
--- a/src/renate/updaters/learner.py
+++ b/src/renate/updaters/learner.py
@@ -370,6 +370,9 @@ class Learner(RenateLightningModule, abc.ABC):
         val_buffer_dir = os.path.join(output_state_dir, "val_memory_buffer")
         os.makedirs(val_buffer_dir, exist_ok=True)
         self._val_memory_buffer.save(val_buffer_dir)
+        learner_checkpoint = torch.load(defaults.learner_state_file(output_state_dir))
+        learner_checkpoint["state_dict"] = {}
+        torch.save(learner_checkpoint, defaults.learner_state_file(output_state_dir))
 
     def load(self, input_state_dir: str) -> None:
         self._val_memory_buffer.load(os.path.join(input_state_dir, "val_memory_buffer"))

--- a/src/renate/updaters/learner.py
+++ b/src/renate/updaters/learner.py
@@ -370,9 +370,6 @@ class Learner(RenateLightningModule, abc.ABC):
         val_buffer_dir = os.path.join(output_state_dir, "val_memory_buffer")
         os.makedirs(val_buffer_dir, exist_ok=True)
         self._val_memory_buffer.save(val_buffer_dir)
-        learner_checkpoint = torch.load(defaults.learner_state_file(output_state_dir))
-        learner_checkpoint["state_dict"] = {}
-        torch.save(learner_checkpoint, defaults.learner_state_file(output_state_dir))
 
     def load(self, input_state_dir: str) -> None:
         self._val_memory_buffer.load(os.path.join(input_state_dir, "val_memory_buffer"))

--- a/src/renate/updaters/model_updater.py
+++ b/src/renate/updaters/model_updater.py
@@ -142,12 +142,12 @@ class RenateModelCheckpoint(ModelCheckpoint):
 
         # Finalize model update.
         pl_module.on_model_update_end()
+        # Overwrite checkpoint.
+        self._save_checkpoint(trainer, str(learner_state_path))
         # Save permanently.
         if trainer.is_global_zero:
-            # Save the buffer only on rank zero.
+            # Save Learner only on rank zero.
             pl_module.save(self._output_state_folder)
-        # Overwrite checkpoint.
-        self._save_checkpoint(trainer, learner_state_path)
 
     def teardown(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
         """
@@ -382,6 +382,7 @@ class ModelUpdater(abc.ABC):
             self._learner_state_file,
             model=self._model,
             logged_metrics=self._logged_metrics,
+            strict=False,
             **self._transforms_kwargs,
             **learner_kwargs,
         )

--- a/src/renate/updaters/model_updater.py
+++ b/src/renate/updaters/model_updater.py
@@ -144,7 +144,7 @@ class RenateModelCheckpoint(ModelCheckpoint):
         pl_module.on_model_update_end()
         # Save permanently.
         if trainer.is_global_zero:
-            # Save Learner only on rank zero.
+            # Save the buffer only on rank zero.
             pl_module.save(self._output_state_folder)
         # Overwrite checkpoint.
         self._save_checkpoint(trainer, str(learner_state_path))

--- a/src/renate/updaters/model_updater.py
+++ b/src/renate/updaters/model_updater.py
@@ -142,16 +142,15 @@ class RenateModelCheckpoint(ModelCheckpoint):
 
         # Finalize model update.
         pl_module.on_model_update_end()
-        # Overwrite checkpoint.
-        self._save_checkpoint(trainer, str(learner_state_path))
         # Save permanently.
         if trainer.is_global_zero:
             # Save Learner only on rank zero.
             pl_module.save(self._output_state_folder)
+        # Overwrite checkpoint.
+        self._save_checkpoint(trainer, str(learner_state_path))
 
     def teardown(self, trainer: Trainer, pl_module: LightningModule, stage: str) -> None:
-        """
-        teardown implements the separation of learner and model at the end of training.
+        """Implements the separation of learner and model at the end of training.
 
         There are two cases two handle.
 
@@ -161,20 +160,20 @@ class RenateModelCheckpoint(ModelCheckpoint):
         deepspeed stage is used. There are three steps here
 
         a. combine all the shards into one big state dict.
-        b. The learner_state_path is a dir (learner.cpkt/). This needs to be deleted first.
-        c. Write the combined state_dict as the learner.cpkt file as a single file.
-        d. Extract the state_dict element from the learner and save that as the model.cpkt.
+        b. The learner_state_path is a dir (learner.ckpt/). This needs to be deleted first.
+        c. Write the combined state_dict as the learner.ckpt file as a single file.
+        d. Extract the state_dict element from the learner and save that as the model.ckpt.
 
         2. If not deepspeed (say DDP or single device):
         The steps are much simpler.
 
-        a. Load the learner.cpkt and extract the state_dict element.
+        a. Load the learner.ckpt and extract the state_dict element.
         b. | Sanitize the extracted state_dict. Learner has the model in a _model attribute.
            | So strip the first "_model." from the keys of the state_dict.
-        c. Save the sanitized model to model.cpkt.
+        c. Save the sanitized model to model.ckpt.
 
         Case 2 is needs to be done even for Case 1 (step d). So teardown is a recursive call in
-        Case 1 which automatically goes to Case 2 as learner.cpkt is file now.
+        Case 1 which automatically goes to Case 2 as learner.ckpt is file now.
         """
 
         if trainer.is_global_zero and (stage == "fit"):
@@ -187,10 +186,14 @@ class RenateModelCheckpoint(ModelCheckpoint):
                 self.teardown(trainer, pl_module, stage)
             elif learner_state_path.exists() and learner_state_path.is_file():
                 # This a normal file. We strip the model of any wrappers and save that.
-                state_dict = torch.load(learner_state_path)["state_dict"]
-                out_sd = {k.replace("_model.", "", 1): v for k, v in state_dict.items()}
-                # Replace only 1 instance because we have to load it into RenateModule.
+                learner_state = torch.load(learner_state_path)
+                out_sd = {
+                    k.replace("_model.", "", 1): v for k, v in learner_state["state_dict"].items()
+                }  # Replace only 1 instance because we have to load it into RenateModule.
                 torch.save(out_sd, defaults.model_file(self.dirpath))
+                # Remove model from learner checkpoint
+                learner_state["state_dict"] = {}
+                torch.save(learner_state, learner_state_path)
 
     def on_exception(
         self, trainer: Trainer, pl_module: LightningModule, exception: BaseException

--- a/test/integration_tests/configs/suites/quick/gdumb.json
+++ b/test/integration_tests/configs/suites/quick/gdumb.json
@@ -6,5 +6,5 @@
   "backend": "local",
   "job_name": "class-incremental-mlp-gdumb",
   "expected_accuracy_linux": [[0.7384999990463257, 0.9304999709129333]],
-  "expected_accuracy_darwin": [[0.43050000071525574, 0.8069999814033508]]
+  "expected_accuracy_darwin": [[0.7384999990463257, 0.9304999709129333]]
 }

--- a/test/integration_tests/configs/suites/quick/gdumb.json
+++ b/test/integration_tests/configs/suites/quick/gdumb.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "class-incremental-mlp-gdumb",
-  "expected_accuracy_linux": [[0.43050000071525574, 0.8069999814033508]],
+  "expected_accuracy_linux": [[0.7384999990463257, 0.9304999709129333]],
   "expected_accuracy_darwin": [[0.43050000071525574, 0.8069999814033508]]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy_linux": [[0.8496000170707703, 0.8496000170707703], [0.8550000190734863, 0.8550000190734863]],
-  "expected_accuracy_darwin": [[0.8585000038146973, 0.8585000038146973]]
+  "expected_accuracy_linux": [[0.8425999879837036, 0.8425999879837036], [0.8550000190734863, 0.8550000190734863]],
+  "expected_accuracy_darwin": [[0.8432000279426575, 0.8432000279426575]]
 }

--- a/test/integration_tests/configs/suites/quick/joint.json
+++ b/test/integration_tests/configs/suites/quick/joint.json
@@ -5,6 +5,6 @@
   "dataset": "fashionmnist.json",
   "backend": "local",
   "job_name": "iid-mlp-joint",
-  "expected_accuracy_linux": [[0.8425999879837036, 0.8425999879837036], [0.8550000190734863, 0.8550000190734863]],
+  "expected_accuracy_linux": [[0.8425999879837036, 0.8425999879837036], [0.8446999788284302, 0.8446999788284302]],
   "expected_accuracy_darwin": [[0.8432000279426575, 0.8432000279426575]]
 }

--- a/test/renate/updaters/test_model_updater.py
+++ b/test/renate/updaters/test_model_updater.py
@@ -59,8 +59,8 @@ def test_model_passed_is_used_as_is(tmpdir):
 
 
 def test_deterministic_updater():
-    # The behavior is always deterministic on CPU but it can become non-deterministic on GPU
-    # When run on CPU this test never fails so it is only useful when tests are run on GPU
+    # The behavior is always deterministic on CPU, but it can become non-deterministic on GPU
+    # When run on CPU this test never fails, so it is only useful when tests are run on GPU
     model1, train_dataset, test_data = pytest.helpers.get_renate_module_mlp_and_data(
         num_inputs=10,
         num_outputs=10,

--- a/test/renate/updaters/test_model_updater.py
+++ b/test/renate/updaters/test_model_updater.py
@@ -34,6 +34,30 @@ def test_simple_model_updater(tmpdir, provide_folder):
     assert not torch.allclose(y_hat_before_train, y_hat_after_train)
 
 
+def test_model_passed_is_used_as_is(tmpdir):
+    """Makes sure that the model passed to the updater is not overwritten by anything in the
+    checkpoint"""
+    model, train_dataset, _ = pytest.helpers.get_renate_module_mlp_and_data(
+        num_inputs=10,
+        num_outputs=10,
+        hidden_size=32,
+        num_hidden_layers=3,
+        train_num_samples=10,
+        test_num_samples=5,
+    )
+    model2 = deepcopy(model)
+    model_updater = pytest.helpers.get_simple_updater(model, output_state_folder=tmpdir)
+    model_updater.update(train_dataset, task_id=defaults.TASK_ID)
+
+    expected_model = deepcopy(model2)
+    model_updater = pytest.helpers.get_simple_updater(model2, input_state_folder=tmpdir)
+    for p1, p2 in zip(
+        expected_model.parameters(),
+        model_updater._learner._model.parameters(),
+    ):
+        assert torch.allclose(p1, p2)
+
+
 def test_deterministic_updater():
     # The behavior is always deterministic on CPU but it can become non-deterministic on GPU
     # When run on CPU this test never fails so it is only useful when tests are run on GPU


### PR DESCRIPTION
Parameters stored in the Learner checkpoint were overwriting parameters of the passed model.

Numbers for Joint/GDumb are expected to change since before these methods were initialized with the weights of the previous model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
