### PR TITLE
Enable Custom Grouping for DataIncrementalScenario

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -112,6 +112,7 @@ if __name__ == "__main__":
             instance_type="ml.g4dn.xlarge",
             n_workers=1,
             max_time=args.max_time,
+            instance_max_time=args.max_time,
             seed=seed,
             job_name=args.job_name[:36],
             devices=1,

--- a/doc/benchmarking/renate_benchmarks.rst
+++ b/doc/benchmarking/renate_benchmarks.rst
@@ -204,7 +204,7 @@ The first part contains all instances with classes 1 and 2, the second with clas
           ids 0 to `num_tasks`. This is the case for time-incremental datasets such as CLEAR or Wild-Time.
         * :code:`data_ids`: Tuple of data identifiers. Used for DomainNet to select order or subset of domains,
           e.g., ``("clipart", "infograph", "painting")``.
-        * :code`groupings`: An alternative to data identifiers that in addition to defining the sequence
+        * :code:`groupings`: An alternative to data identifiers that in addition to defining the sequence
           allows to combine different domains to one chunk, e.g., ``(("clipart", ), ("infograph", "painting"))``.
     * - :py:class:`~renate.benchmark.scenarios.ClassIncrementalScenario`
       - Creates data partitions by splitting the data according to class labels.

--- a/doc/benchmarking/renate_benchmarks.rst
+++ b/doc/benchmarking/renate_benchmarks.rst
@@ -187,7 +187,7 @@ The first part contains all instances with classes 1 and 2, the second with clas
 .. code-block:: python
 
     config_space["scenario_name"] = "ClassIncrementalScenario"
-    config_space["class_groupings"] = ((1, 2), (3, 4))
+    config_space["groupings"] = ((1, 2), (3, 4))
 
 .. list-table:: Renate Scenario Overview
     :widths: 15 35 35
@@ -202,10 +202,13 @@ The first part contains all instances with classes 1 and 2, the second with clas
         Data is presented data by data, where the data could represent a domain or a time slice.
       - * :code:`num_tasks`: You can provide this argument if the different datasets are identified by
           ids 0 to `num_tasks`. This is the case for time-incremental datasets such as CLEAR or Wild-Time.
-        * :code:`data_ids`: List of data identifiers. Used for DomainNet to select order or subset of domains.
+        * :code:`data_ids`: Tuple of data identifiers. Used for DomainNet to select order or subset of domains,
+          e.g., ``("clipart", "infograph", "painting")``.
+        * :code`groupings`: An alternative to data identifiers that in addition to defining the sequence
+          allows to combine different domains to one chunk, e.g., ``(("clipart", ), ("infograph", "painting"))``.
     * - :py:class:`~renate.benchmark.scenarios.ClassIncrementalScenario`
       - Creates data partitions by splitting the data according to class labels.
-      - * :code:`class_groupings`: Tuple of tuples containing the class labels, e.g., ``((1, ), (2, 3, 4))``.
+      - * :code:`groupings`: Tuple of tuples containing the class labels, e.g., ``((1, ), (2, 3, 4))``.
     * - :py:class:`~renate.benchmark.scenarios.FeatureSortingScenario`
       - Splits data into different tasks after sorting the data according to a specific feature.
         Can be used for image data as well. In that case channels are selected and we select according to

--- a/examples/benchmarking/class_incremental_learning_cifar10_der.py
+++ b/examples/benchmarking/class_incremental_learning_cifar10_der.py
@@ -21,7 +21,7 @@ config_space = {
     "scenario_name": "ClassIncrementalScenario",
     "dataset_name": "CIFAR10",
     "val_size": 0,
-    "class_groupings": ((0, 1), (2, 3), (4, 5), (6, 7), (8, 9)),
+    "groupings": ((0, 1), (2, 3), (4, 5), (6, 7), (8, 9)),
     "num_outputs": 10,
 }
 

--- a/examples/simple_classifier_cifar10/renate_config.py
+++ b/examples/simple_classifier_cifar10/renate_config.py
@@ -37,7 +37,7 @@ def data_module_fn(data_path: str, chunk_id: int, seed: int = defaults.SEED) -> 
     )
     class_incremental_scenario = ClassIncrementalScenario(
         data_module=data_module,
-        class_groupings=((0, 1, 2, 3, 4), (5, 6, 7, 8, 9)),
+        groupings=((0, 1, 2, 3, 4), (5, 6, 7, 8, 9)),
         chunk_id=chunk_id,
     )
     return class_incremental_scenario

--- a/examples/train_mlp_locally/renate_config.py
+++ b/examples/train_mlp_locally/renate_config.py
@@ -28,7 +28,7 @@ def data_module_fn(data_path: str, chunk_id: int, seed: int = defaults.SEED) -> 
 
     class_incremental_scenario = ClassIncrementalScenario(
         data_module=data_module,
-        class_groupings=((0, 1, 2, 3, 4), (5, 6, 7, 8, 9)),
+        groupings=((0, 1, 2, 3, 4), (5, 6, 7, 8, 9)),
         chunk_id=chunk_id,
     )
     return class_incremental_scenario

--- a/src/renate/benchmark/datasets/wild_time_data.py
+++ b/src/renate/benchmark/datasets/wild_time_data.py
@@ -90,7 +90,7 @@ class WildTimeDataModule(DataIncrementalDataModule):
             "time_step": available_time_steps(self._dataset_name)[self.data_id],
             "data_dir": self._data_path,
             "in_memory": self._dataset_name != "fmow",
-            "transform": None if self._dataset_name != "fmow" else lambda x: x,
+            "transform": None if self._dataset_name not in ["fmow", "yearbook"] else lambda x: x,
         }
         if self._tokenizer:
             kwargs["transform"] = lambda x: self._tokenizer(x, **(self._tokenizer_kwargs or {}))

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -334,7 +334,6 @@ def train_transform(dataset_name: str, model_name: Optional[str] = None) -> Opti
                     transforms.Resize(224),
                     transforms.RandomHorizontalFlip(),
                     default_transform(dataset_name),
-                    transforms.Normalize(0.5055697, 0.27123657),
                     transforms.Lambda(lambda x: x.repeat(3, 1, 1)),
                 ]
             )

--- a/src/renate/benchmark/experiment_config.py
+++ b/src/renate/benchmark/experiment_config.py
@@ -334,6 +334,7 @@ def train_transform(dataset_name: str, model_name: Optional[str] = None) -> Opti
                     transforms.Resize(224),
                     transforms.RandomHorizontalFlip(),
                     default_transform(dataset_name),
+                    transforms.Normalize(0.5055697, 0.27123657),
                     transforms.Lambda(lambda x: x.repeat(3, 1, 1)),
                 ]
             )

--- a/src/renate/cli/parsing_functions.py
+++ b/src/renate/cli/parsing_functions.py
@@ -862,7 +862,7 @@ def get_argument_type(arg_spec: inspect.FullArgSpec, argument_name: str) -> Type
     return argument_type
 
 
-def to_dense_str(value: Union[bool, List, Tuple]) -> str:
+def to_dense_str(value: Union[bool, List, Tuple, None]) -> str:
     """Converts a variable to string without empty spaces."""
     return str(value).replace(" ", "")
 

--- a/test/dummy_datasets.py
+++ b/test/dummy_datasets.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple
 
 import torch
 from torch.utils.data import Dataset

--- a/test/dummy_datasets.py
+++ b/test/dummy_datasets.py
@@ -1,11 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 from torch.utils.data import Dataset
 
 from renate import defaults
+from renate.benchmark.datasets.base import DataIncrementalDataModule
 from renate.data.data_module import RenateDataModule
 from renate.utils.pytorch import get_generator
 
@@ -69,3 +71,38 @@ class DummyTorchVisionDataModule(RenateDataModule):
         self._train_data, self._val_data = self._split_train_val_data(train_data)
         self.X_test, self.y_test = self._get_random_data()
         self._test_data = DummyDataset(self.X_test, self.y_test, self._transform)
+
+
+class DummyDataIncrementalDataModule(DataIncrementalDataModule):
+    """Simple dataset to test whether DataIncrementalDataModule or DataIncrementalScenario work.
+
+    This data module gives access to 5 different datasets with ids [0, 1, 2, 3, 4].
+    The labels of dataset with data_id=i are all i.
+    """
+
+    def __init__(
+        self,
+        data_id: int,
+        input_shape: Tuple[int, ...],
+        transform: Optional[Callable] = None,
+        val_size: float = defaults.VALIDATION_SIZE,
+        seed: int = defaults.SEED,
+    ):
+        super().__init__(data_path="", data_id=data_id, val_size=val_size, seed=seed)
+        rng = get_generator(self._seed)
+
+        def get_data(i):
+            return DummyDataset(
+                data=torch.rand((100, *input_shape), generator=rng, dtype=torch.float32),
+                targets=torch.zeros(100) + i,
+                transform=transform,
+            )
+
+        self._datasets = [[get_data(i) for _ in range(2)] for i in range(5)]
+
+    def prepare_data(self) -> None:
+        pass
+
+    def setup(self):
+        self._train_data, self._test_data = self._datasets[self.data_id]
+        self._train_data, self._val_data = self._split_train_val_data(self._train_data)

--- a/test/integration_tests/configs/scenarios/class-incremental-2updates.json
+++ b/test/integration_tests/configs/scenarios/class-incremental-2updates.json
@@ -1,7 +1,7 @@
 {
   "val_size": 0.05,
   "scenario_name": "ClassIncrementalScenario",
-  "class_groupings": [[0, 1], [2, 3]],
+  "groupings": [[0, 1], [2, 3]],
   "num_tasks": 2,
   "max_epochs": 5
 }

--- a/test/integration_tests/configs/scenarios/class-incremental-5updates.json
+++ b/test/integration_tests/configs/scenarios/class-incremental-5updates.json
@@ -1,7 +1,7 @@
 {
   "val_size": 0.05,
   "scenario_name": "ClassIncrementalScenario",
-  "class_groupings": [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]],
+  "groupings": [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]],
   "num_tasks": 5,
   "max_epochs": 50
 }

--- a/test/renate/benchmark/test_experimentation_config.py
+++ b/test/renate/benchmark/test_experimentation_config.py
@@ -157,7 +157,7 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
                 "pretrained_model_name": "distilbert-base-uncased",
                 "input_column": "text",
                 "target_column": "coarse_label",
-                "class_groupings": ((0, 1), (2, 3), (4, 5)),
+                "groupings": ((0, 1), (2, 3), (4, 5)),
             },
             ClassIncrementalScenario,
             3,
@@ -219,7 +219,14 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
         (
             "DataIncrementalScenario",
             "DomainNet",
-            {"data_ids": ["clipart", "infograph"]},
+            {"data_ids": ("clipart", "infograph")},
+            DataIncrementalScenario,
+            2,
+        ),
+        (
+            "DataIncrementalScenario",
+            "DomainNet",
+            {"groupings": (("clipart", "infograph"), "painting")},
             DataIncrementalScenario,
             2,
         ),
@@ -231,10 +238,11 @@ def test_get_scenario_fails_for_unknown_scenario(tmpdir):
         "permutation",
         "feature_sorting",
         "hue_shift",
-        "time_with_clear",
+        "data_incremental with CLEAR",
         "wild_time_text_with_tokenizer",
         "wild_time_image_all_tasks",
-        "domainnet",
+        "domainnet_by data_id",
+        "domainnet by groupings",
     ],
 )
 @pytest.mark.parametrize("val_size", (0, 0.5), ids=["no_val", "val"])
@@ -258,7 +266,7 @@ def test_data_module_fn(
     )
     assert isinstance(scenario, expected_scenario_class)
     if expected_scenario_class == ClassIncrementalScenario:
-        assert scenario._class_groupings == scenario_kwargs["class_groupings"]
+        assert scenario._class_groupings == scenario_kwargs["groupings"]
     elif expected_scenario_class == FeatureSortingScenario:
         assert scenario._feature_idx == scenario_kwargs["feature_idx"]
         assert scenario._randomness == scenario_kwargs["randomness"]

--- a/test/renate/benchmark/test_experimentation_config.py
+++ b/test/renate/benchmark/test_experimentation_config.py
@@ -5,7 +5,7 @@ from torch.nn import Linear
 from torch.optim import AdamW, SGD
 from torch.optim.lr_scheduler import CosineAnnealingLR, StepLR
 from torchmetrics.classification import MulticlassAccuracy
-from torchvision.transforms import Compose, Normalize
+from torchvision.transforms import Compose, Normalize, ToTensor
 
 from renate.benchmark import experiment_config
 from renate.benchmark.datasets.nlp_datasets import HuggingFaceTextDataModule
@@ -281,30 +281,27 @@ def test_data_module_fn(
 
 
 @pytest.mark.parametrize(
-    "dataset_name,use_transforms,test_compose",
+    "dataset_name,expected_train_transform_class, expected_test_transform_class,model_name",
     (
-        ("MNIST", False, False),
-        ("FashionMNIST", False, False),
-        ("CIFAR10", True, False),
-        ("CIFAR100", True, False),
-        ("CLEAR10", True, True),
-        ("DomainNet", True, True),
-        ("hfd-rotten_tomatoes", False, False),
-        ("fmow", True, True),
+        ("MNIST", type(None), type(None), "ResNet18CIFAR"),
+        ("FashionMNIST", type(None), type(None), "ResNet18CIFAR"),
+        ("CIFAR10", Compose, Normalize, "ResNet18CIFAR"),
+        ("CIFAR100", Compose, Normalize, "ResNet18CIFAR"),
+        ("CLEAR10", Compose, Compose, "ResNet18"),
+        ("DomainNet", Compose, Compose, "VisionTransformerB16"),
+        ("hfd-rotten_tomatoes", type(None), type(None), "HuggingFaceTransformer"),
+        ("fmow", Compose, Compose, "ResNet18"),
+        ("yearbook", ToTensor, ToTensor, "ResNet18CIFAR"),
+        ("yearbook", Compose, Compose, "VisionTransformerB16"),
     ),
 )
-def test_transforms(dataset_name, use_transforms, test_compose):
-    train_preprocessing = train_transform(dataset_name)
-    test_preprocessing = experiment_config.test_transform(dataset_name)
-    if use_transforms:
-        assert isinstance(train_preprocessing, Compose)
-        if test_compose:
-            assert isinstance(test_preprocessing, Compose)
-        else:
-            assert isinstance(test_preprocessing, Normalize)
-    else:
-        assert train_preprocessing is None
-        assert test_preprocessing is None
+def test_transforms(
+    dataset_name, expected_train_transform_class, expected_test_transform_class, model_name
+):
+    train_preprocessing = train_transform(dataset_name, model_name)
+    test_preprocessing = experiment_config.test_transform(dataset_name, model_name)
+    assert isinstance(train_preprocessing, expected_train_transform_class)
+    assert isinstance(test_preprocessing, expected_test_transform_class)
 
 
 def test_transforms_fails_for_unknown_dataset():

--- a/test/renate/benchmark/test_scenarios.py
+++ b/test/renate/benchmark/test_scenarios.py
@@ -147,7 +147,7 @@ def test_data_incremental_scenario_wrong_input(data_ids, groupings, expected_err
     """Scenario expect either data_ids or groupings."""
     with pytest.raises(ValueError, match=expected_error_message):
         DataIncrementalScenario(
-            data_module=DummyTorchVisionDataModule(),
+            data_module=DummyDataIncrementalDataModule(data_id=0, input_shape=(2, 2)),
             data_ids=data_ids,
             groupings=groupings,
             chunk_id=0,

--- a/test/renate/benchmark/test_scenarios.py
+++ b/test/renate/benchmark/test_scenarios.py
@@ -32,7 +32,7 @@ from renate.utils.pytorch import randomly_split_data
             {
                 "num_tasks": 3,
                 "chunk_id": 4,  # Wrong chunk id
-                "class_groupings": [[0, 1, 2], [3, 5, 9], [4, 6, 7, 8]],
+                "groupings": ((0, 1, 2), (3, 5, 9), (4, 6, 7, 8)),
             },
         ],
         [PermutationScenario, {"num_tasks": 3, "chunk_id": 2}],  # Missing input dim
@@ -49,29 +49,29 @@ def test_failing_to_init(tmpdir, scenario_cls, kwargs):
 
 def test_class_incremental_scenario():
     data_module = DummyTorchVisionDataModule(val_size=0.3, seed=42)
-    class_groupings = [[0, 1, 3], [2], [3, 4]]
+    groupings = ((0, 1, 3), (2,), (3, 4))
     train_data_class_counts = Counter({3: 16, 4: 15, 0: 15, 2: 13, 1: 11})
     val_data_class_counts = Counter({1: 9, 2: 7, 4: 5, 0: 5, 3: 4})
     test_data_class_counts = Counter({0: 20, 1: 20, 2: 20, 3: 20, 4: 20})
-    for i in range(len(class_groupings)):
+    for i in range(len(groupings)):
         scenario = ClassIncrementalScenario(
-            data_module=data_module, class_groupings=class_groupings, chunk_id=i
+            data_module=data_module, groupings=groupings, chunk_id=i
         )
         scenario.prepare_data()
         scenario.setup()
         train_data = scenario.train_data()
         val_data = scenario.val_data()
-        assert len(train_data) == sum([train_data_class_counts[c] for c in class_groupings[i]])
-        assert len(val_data) == sum([val_data_class_counts[c] for c in class_groupings[i]])
+        assert len(train_data) == sum([train_data_class_counts[c] for c in groupings[i]])
+        assert len(val_data) == sum([val_data_class_counts[c] for c in groupings[i]])
         for j, test_data in enumerate(scenario.test_data()):
-            assert len(test_data) == sum([test_data_class_counts[c] for c in class_groupings[j]])
+            assert len(test_data) == sum([test_data_class_counts[c] for c in groupings[j]])
 
 
-def test_class_incremental_scenario_class_grouping_error():
+def test_class_incremental_scenario_groupings_error():
     """Classes selected do not exist in data."""
     scenario = ClassIncrementalScenario(
         data_module=DummyTorchVisionDataModule(val_size=0.3, seed=42),
-        class_groupings=((0, 1, 3), (2, 200)),
+        groupings=((0, 1, 3), (2, 200)),
         chunk_id=0,
     )
     scenario.prepare_data()
@@ -79,12 +79,34 @@ def test_class_incremental_scenario_class_grouping_error():
         scenario.setup()
 
 
-def test_data_incremental_scenario_init_error():
+def test_data_incremental_scenario_data_module_error():
     """Check that DataIncrementalScenario raises Exception for unsupported DataModule."""
     with pytest.raises(ValueError, match=r"This scenario is only compatible with*"):
         DataIncrementalScenario(
             data_module=DummyTorchVisionDataModule(),
-            data_ids=[0, 1],
+            data_ids=(0, 1),
+            chunk_id=0,
+        )
+
+
+@pytest.mark.parametrize(
+    "data_ids,groupings,expected_error_message",
+    (
+        (
+            (0, 1),
+            ((0,), (1,)),
+            "Either `data_ids` or `groupings` must be provided. Both were provided.",
+        ),
+        (None, None, "Either `data_ids` or `groupings` must be provided. None was provided."),
+    ),
+)
+def test_data_incremental_scenario_wrong_input(data_ids, groupings, expected_error_message):
+    """Scenario expect either data_ids or groupings."""
+    with pytest.raises(ValueError, match=expected_error_message):
+        DataIncrementalScenario(
+            data_module=DummyTorchVisionDataModule(),
+            data_ids=data_ids,
+            groupings=groupings,
             chunk_id=0,
         )
 

--- a/test/renate/benchmark/test_scenarios.py
+++ b/test/renate/benchmark/test_scenarios.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from torchvision.transforms.functional import rotate
 
-from dummy_datasets import DummyTorchVisionDataModule
+from dummy_datasets import DummyDataIncrementalDataModule, DummyTorchVisionDataModule
 from renate.benchmark.datasets.vision_datasets import TorchVisionDataModule
 from renate.benchmark.scenarios import (
     ClassIncrementalScenario,
@@ -77,6 +77,49 @@ def test_class_incremental_scenario_groupings_error():
     scenario.prepare_data()
     with pytest.raises(ValueError, match=r"Chunk 1 does not contain classes \[200\]."):
         scenario.setup()
+
+
+def test_data_incremental_scenario_grouping():
+    """Test whether grouping in DataIncrementalScenario works"""
+    scenario = DataIncrementalScenario(
+        data_module=DummyDataIncrementalDataModule(0, (10, 1), val_size=0.2),
+        chunk_id=0,
+        groupings=((0, 1), (2,)),
+    )
+    scenario.prepare_data()
+    scenario.setup()
+    assert set(int(scenario.train_data()[i][1]) for i in range(80)) == {0}
+    assert set(int(scenario.train_data()[i][1]) for i in range(80, 160)) == {1}
+    assert set(int(scenario.val_data()[i][1]) for i in range(20)) == {0}
+    assert set(int(scenario.val_data()[i][1]) for i in range(20, 40)) == {1}
+    assert set(int(scenario.test_data()[0][i][1]) for i in range(100)) == {0}
+    assert set(int(scenario.test_data()[0][i][1]) for i in range(100, 200)) == {1}
+    assert set(int(scenario.test_data()[1][i][1]) for i in range(100)) == {2}
+    assert len(scenario.train_data()) == 160
+    assert len(scenario.val_data()) == 40
+    assert len(scenario.test_data()) == 2
+    assert len(scenario.test_data()[0]) == 200
+    assert len(scenario.test_data()[1]) == 100
+
+
+def test_data_incremental_scenario_data_ids():
+    """Test whether data_ids in DataIncrementalScenario works"""
+    scenario = DataIncrementalScenario(
+        data_module=DummyDataIncrementalDataModule(0, (10, 1), val_size=0.2),
+        chunk_id=1,
+        data_ids=(3, 4),
+    )
+    scenario.prepare_data()
+    scenario.setup()
+    assert set(int(scenario.train_data()[i][1]) for i in range(80)) == {4}
+    assert set(int(scenario.val_data()[i][1]) for i in range(20)) == {4}
+    assert set(int(scenario.test_data()[0][i][1]) for i in range(100)) == {3}
+    assert set(int(scenario.test_data()[1][i][1]) for i in range(100)) == {4}
+    assert len(scenario.train_data()) == 80
+    assert len(scenario.val_data()) == 20
+    assert len(scenario.test_data()) == 2
+    assert len(scenario.test_data()[0]) == 100
+    assert len(scenario.test_data()[1]) == 100
 
 
 def test_data_incremental_scenario_data_module_error():

--- a/test/renate/cli/test_parsing_functions.py
+++ b/test/renate/cli/test_parsing_functions.py
@@ -90,7 +90,7 @@ def test_get_function_args(all_args, ignore_args):
         "data_path",
         "val_size",
         "seed",
-        "class_groupings",
+        "groupings",
         "optional_tuple",
         "optional_float",
         "list_param",
@@ -117,7 +117,7 @@ def test_get_function_args(all_args, ignore_args):
                 "default": 0,
                 "true_type": int,
             },
-            "class_groupings": {
+            "groupings": {
                 "type": str,
                 "argument_group": CUSTOM_ARGS_GROUP,
                 "default": "((0,1),(2,3,4))",
@@ -207,7 +207,7 @@ def test_get_fn_kwargs_helper_functions():
     and the Python function."""
     expected_data_module_kwargs = {
         "data_path": "home/data/path",
-        "class_groupings": ((1, 2), (3, 4)),
+        "groupings": ((1, 2), (3, 4)),
         "optional_float": None,
         "bool_param": False,
     }
@@ -215,7 +215,7 @@ def test_get_fn_kwargs_helper_functions():
         "data_path": expected_data_module_kwargs["data_path"],
         "model_state_url": "home/model/state",
         "unused_config": 1,
-        "class_groupings": to_dense_str(expected_data_module_kwargs["class_groupings"]),
+        "groupings": to_dense_str(expected_data_module_kwargs["groupings"]),
         "optional_float": to_dense_str(expected_data_module_kwargs["optional_float"]),
         "bool_param": to_dense_str(expected_data_module_kwargs["bool_param"]),
         "num_outputs": 10,

--- a/test/renate/renate_config_files/config.py
+++ b/test/renate/renate_config_files/config.py
@@ -22,7 +22,7 @@ def data_module_fn(
     data_path: str,
     val_size: float = 0.0,
     seed: int = 0,
-    class_groupings: Tuple[Tuple[int]] = ((0, 1), (2, 3, 4)),
+    groupings: Tuple[Tuple[int]] = ((0, 1), (2, 3, 4)),
     optional_tuple: Optional[Tuple[float]] = None,
     optional_float: Optional[float] = None,
     list_param: list = [1, 2],

--- a/test/renate/renate_config_files/config_scenario.py
+++ b/test/renate/renate_config_files/config_scenario.py
@@ -23,13 +23,13 @@ def data_module_fn(
     chunk_id: Optional[int] = None,
     val_size: float = 0.0,
     seed: int = 0,
-    class_groupings: Tuple[Tuple[int, ...], ...] = ((0, 1), (2, 3, 4)),
+    groupings: Tuple[Tuple[int, ...], ...] = ((0, 1), (2, 3, 4)),
 ) -> Scenario:
     data_module = DummyTorchVisionDataModule(transform=None, val_size=val_size, seed=seed)
     return ClassIncrementalScenario(
         data_module=data_module,
         chunk_id=chunk_id,
-        class_groupings=class_groupings,
+        groupings=groupings,
     )
 
 


### PR DESCRIPTION
Rename `class_groupings` to `groupings` in `ClassIncrementalScenario`.

`DataIncrementalScenario` has now an argument `groupings` that allows grouping datasets similar to the `groupings` in `ClassIncrementalScenario` for classes.

Added support for training on `yearbook` with ViT.

Functionality exposed for benchmarking.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
