### PR TITLE
Make offline ER us total batch size in first update

### DIFF
--- a/src/renate/updaters/experimental/offline_er.py
+++ b/src/renate/updaters/experimental/offline_er.py
@@ -85,20 +85,10 @@ class OfflineExperienceReplayLearner(ReplayLearner):
                 collate_fn=self._train_collate_fn,
             )
         else:
-            # Manually create a dataloader for the current task with total batch size.
-            train_dataset = _TransformedDataset(
-                self._train_dataset,
-                transform=self._train_transform,
-                target_transform=self._train_target_transform,
-            )
-            loaders["current_task"] = DataLoader(
-                train_dataset,
-                batch_size=self._batch_size + self._memory_batch_size,
-                shuffle=True,
-                generator=self._rng,
-                pin_memory=True,
-                collate_fn=self._train_collate_fn,
-            )
+            batch_size = self._batch_size
+            self._batch_size += self._memory_batch_size
+            loaders["current_task"] = super().train_dataloader()
+            self._batch_size = batch_size
         return CombinedLoader(loaders, mode="max_size_cycle")
 
     def on_model_update_end(self) -> None:

--- a/src/renate/updaters/experimental/offline_er.py
+++ b/src/renate/updaters/experimental/offline_er.py
@@ -13,6 +13,7 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader, Dataset
 
 from renate import defaults
+from renate.data.datasets import _TransformedDataset
 from renate.models import RenateModule
 from renate.types import NestedTensors
 from renate.updaters.learner import ReplayLearner
@@ -71,13 +72,28 @@ class OfflineExperienceReplayLearner(ReplayLearner):
         self._num_points_current_task = len(train_dataset)
 
     def train_dataloader(self) -> DataLoader:
-        train_loader = super().train_dataloader()
-        loaders = {"current_task": train_loader}
+        loaders = {}
         if len(self._memory_buffer) > self._memory_batch_size:
+            loaders["current_task"] = super().train_dataloader()
             loaders["memory"] = DataLoader(
                 dataset=self._memory_buffer,
                 batch_size=self._memory_batch_size,
                 drop_last=True,
+                shuffle=True,
+                generator=self._rng,
+                pin_memory=True,
+                collate_fn=self._train_collate_fn,
+            )
+        else:
+            # Manually create a dataloader for the current task with total batch size.
+            train_dataset = _TransformedDataset(
+                self._train_dataset,
+                transform=self._train_transform,
+                target_transform=self._train_target_transform,
+            )
+            loaders["current_task"] = DataLoader(
+                train_dataset,
+                batch_size=self._batch_size + self._memory_batch_size,
                 shuffle=True,
                 generator=self._rng,
                 pin_memory=True,

--- a/src/renate/updaters/experimental/offline_er.py
+++ b/src/renate/updaters/experimental/offline_er.py
@@ -13,7 +13,6 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader, Dataset
 
 from renate import defaults
-from renate.data.datasets import _TransformedDataset
 from renate.models import RenateModule
 from renate.types import NestedTensors
 from renate.updaters.learner import ReplayLearner

--- a/test/integration_tests/configs/suites/quick/offline-er.json
+++ b/test/integration_tests/configs/suites/quick/offline-er.json
@@ -5,6 +5,6 @@
     "dataset": "cifar10.json",
     "backend": "local",
     "job_name": "class-incremental-mlp-offline-er",
-    "expected_accuracy_linux": [[0.7319999933242798, 0.4699999988079071], [0.7515000104904175, 0.49300000071525574]],
-    "expected_accuracy_darwin": [[0.7300000190734863, 0.5350000262260437]]
+    "expected_accuracy_linux": [[0.6980000138282776, 0.546999990940094]],
+    "expected_accuracy_darwin": [[0.7315000295639038, 0.49000000953674316]]
   }

--- a/test/integration_tests/configs/suites/quick/offline-er.json
+++ b/test/integration_tests/configs/suites/quick/offline-er.json
@@ -5,6 +5,6 @@
     "dataset": "cifar10.json",
     "backend": "local",
     "job_name": "class-incremental-mlp-offline-er",
-    "expected_accuracy_linux": [[0.6980000138282776, 0.546999990940094]],
+    "expected_accuracy_linux": [[0.6980000138282776, 0.546999990940094], [0.6514999866485596, 0.3725000023841858]],
     "expected_accuracy_darwin": [[0.7315000295639038, 0.49000000953674316]]
   }


### PR DESCRIPTION
Offline ER currently uses only `batch_size` in the first model update. This PR makes it use `batch_size + memory_batch_size` to be comparable to joint training, et cetera. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
