### PR TITLE
Speeding up unitests

### DIFF
--- a/test/renate/benchmark/models/test_l2p.py
+++ b/test/renate/benchmark/models/test_l2p.py
@@ -22,18 +22,21 @@ def test_prompt_pool():
     assert out.shape == (B, Lp * N, feat_dim)
 
 
+@pytest.mark.slow
 def test_prompted_vision_transformer():
     combined = LearningToPromptTransformer()
     inp = torch.rand(1, 3, 224, 224)
     assert combined(inp).shape == torch.Size((1, 10))
 
 
+@pytest.mark.slow
 def test_prompted_text_transformer():
     model = LearningToPromptTransformer(pretrained_model_name_or_path="bert-base-uncased")
     inp = {"input_ids": torch.randint(0, 3000, (10, 128))}
     assert model(inp).shape == torch.Size((10, 10))
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "cls,arg,argval,error",
     [
@@ -47,6 +50,7 @@ def test_pool_vision_transformer_raises_errors(cls, arg, argval, error):
         cls(**{arg: argval})
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "backbone,num_trainable_params",
     [
@@ -64,6 +68,7 @@ def test_prompt_vision_transformer_trainable_parameters(backbone, num_trainable_
     assert n == num_trainable_params
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("backbone", ["google/vit-base-patch16-224", "bert-base-uncased"])
 @pytest.mark.parametrize("prompt", [None, torch.rand(3, 10, 768)])
 @pytest.mark.parametrize("cls_feat", [True, False])

--- a/test/renate/benchmark/models/test_text_transformer.py
+++ b/test/renate/benchmark/models/test_text_transformer.py
@@ -6,6 +6,7 @@ import torch
 from renate.benchmark.models.transformer import HuggingFaceSequenceClassificationTransformer
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased", "bert-base-uncased"])
 def test_init(model_name):
     HuggingFaceSequenceClassificationTransformer(
@@ -13,6 +14,7 @@ def test_init(model_name):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "model_name,input_dim",
     [

--- a/test/renate/benchmark/models/test_vision_transformer.py
+++ b/test/renate/benchmark/models/test_vision_transformer.py
@@ -6,6 +6,7 @@ import torch
 from renate.defaults import TASK_ID
 
 
+@pytest.mark.slow
 def test_renate_vision_transformer_init():
     pytest.helpers.get_renate_module_vision_transformer(sub_class="visiontransformercifar")
     pytest.helpers.get_renate_module_vision_transformer(sub_class="visiontransformerb16")
@@ -41,6 +42,7 @@ def test_renate_vision_transformer_fwd(sub_class, input_dim):
 # for m in [VisionTransformerB16, VisionTransformerB32, VisionTransformerCIFAR,
 #           VisionTransformerH14, VisionTransformerL16, VisionTransformerL32]:
 #     print(len(list(m()._backbone.parameters())))
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "sub_class, expected_num_params",
     [

--- a/test/renate/benchmark/test_experimentation_config.py
+++ b/test/renate/benchmark/test_experimentation_config.py
@@ -345,6 +345,7 @@ def test_lr_scheduler_fn_fails_for_unknown_scheduler():
         lr_scheduler_fn(unknown_lr_scheduler)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("model_name", [model_name for model_name in models])
 @pytest.mark.parametrize("updater", ("ER", "Avalanche-iCaRL"))
 def test_prediction_strategy_is_correctly_set(model_name, updater):

--- a/test/renate/benchmark/test_experimentation_config.py
+++ b/test/renate/benchmark/test_experimentation_config.py
@@ -34,6 +34,7 @@ from renate.benchmark.scenarios import (
 from renate.models.prediction_strategies import ICaRLClassificationStrategy
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "model_name,expected_model_class",
     [(model_name, model_class) for model_name, model_class in models.items()],

--- a/test/renate/data/test_data_module.py
+++ b/test/renate/data/test_data_module.py
@@ -134,6 +134,7 @@ def test_tiny_imagenet_data_module(tmpdir):
     assert train_data[0][0].size() == test_data[0][0].size() == (3, 64, 64)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "dataset_name,input_column,target_column",
     [

--- a/test/renate/data/test_data_module.py
+++ b/test/renate/data/test_data_module.py
@@ -134,11 +134,10 @@ def test_tiny_imagenet_data_module(tmpdir):
     assert train_data[0][0].size() == test_data[0][0].size() == (3, 64, 64)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "dataset_name,input_column,target_column",
     [
-        ("rotten_tomatoes", "text", "label"),
+        ("dbrd", "text", "label"),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/renate/data/test_data_module.py
+++ b/test/renate/data/test_data_module.py
@@ -138,7 +138,7 @@ def test_tiny_imagenet_data_module(tmpdir):
 @pytest.mark.parametrize(
     "dataset_name,input_column,target_column",
     [
-        ("rotten-tomatoes", "text", "label"),
+        ("rotten_tomatoes", "text", "label"),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/renate/data/test_data_module.py
+++ b/test/renate/data/test_data_module.py
@@ -138,7 +138,7 @@ def test_tiny_imagenet_data_module(tmpdir):
 @pytest.mark.parametrize(
     "dataset_name,input_column,target_column",
     [
-        ("dbrd", "text", "label"),
+        ("rotten-tomatoes", "text", "label"),
     ],
 )
 @pytest.mark.parametrize(
@@ -180,6 +180,7 @@ def test_hugging_face_data_module(
         assert isinstance(inputs["attention_mask"], torch.Tensor)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("column", ("input", "target"), ids=("input", "target"))
 def test_hugging_face_exception_raised_with_wrong_column(tmpdir, column):
     input_column = "text"

--- a/test/renate/utils/test_pytorch.py
+++ b/test/renate/utils/test_pytorch.py
@@ -130,9 +130,12 @@ def test_complementary_indices(num_outputs, indices, expected_output):
 def test_unique_classes(tmpdir, test_dataset):
     if test_dataset:
         for data_id in range(5):
-            module = DummyDataIncrementalDataModule(data_id, (10, 10), transform=None, val_size=0)
-            module.setup()
-            train_data = module.train_data()
+            data_module = DummyDataIncrementalDataModule(
+                data_id, (10, 10), transform=None, val_size=0
+            )
+            data_module.prepare_data()
+            data_module.setup()
+            train_data = data_module.train_data()
             predicted_unique = set(int(x) for x in unique_classes(train_data))
             assert predicted_unique == {data_id}
     else:

--- a/test/renate/utils/test_pytorch.py
+++ b/test/renate/utils/test_pytorch.py
@@ -19,6 +19,8 @@ from renate.utils.pytorch import (
     unique_classes,
 )
 
+from dummy_datasets import DummyDataIncrementalDataModule
+
 
 @pytest.mark.parametrize("model", [torchvision.models.resnet18(pretrained=True)])
 def test_reinitialize_model_parameters(model: torch.nn.Module):
@@ -130,18 +132,12 @@ def test_complementary_indices(num_outputs, indices, expected_output):
 @pytest.mark.parametrize("test_dataset", [True, False])
 def test_unique_classes(tmpdir, test_dataset):
     if test_dataset:
-        class_groupings = np.arange(0, 100).reshape(10, 10).tolist()
-        data_module = TorchVisionDataModule(tmpdir, dataset_name="CIFAR100", val_size=0.2)
-        data_module.prepare_data()
-        for chunk_id in range(len(class_groupings)):
-            scenario = ClassIncrementalScenario(
-                data_module=data_module, groupings=class_groupings, chunk_id=chunk_id
-            )
-            scenario.setup()
-            ds = scenario.val_data()
-            predicted_unique = unique_classes(ds)
-
-            assert predicted_unique == set(class_groupings[chunk_id])
+        for data_id in range(5):
+            module = DummyDataIncrementalDataModule(data_id, (10, 10), transform=None, val_size=0)
+            module.setup()
+            train_data = module.train_data()
+            predicted_unique = set(int(x) for x in unique_classes(train_data))
+            assert predicted_unique == {data_id}
     else:
         X = torch.randn(10, 3)
         y = torch.arange(0, 10)

--- a/test/renate/utils/test_pytorch.py
+++ b/test/renate/utils/test_pytorch.py
@@ -1,13 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import numpy as np
 import pytest
 import torch
 import torchvision
 from torch.utils.data import Sampler, TensorDataset
 
-from renate.benchmark.datasets.vision_datasets import TorchVisionDataModule
-from renate.benchmark.scenarios import ClassIncrementalScenario
 from renate.memory.buffer import ReservoirBuffer
 from renate.utils import pytorch
 from renate.utils.pytorch import (


### PR DESCRIPTION
Some of the unit-tests run for a long time. The slowest one is the `test_unique_classes`. This PR simplifies this, and marks a few other long running ones (mostly ones that download HF models/datasets) with a `pytest.mark.slow` decorator. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
