### PR TITLE
Avoid In-Memory Dataset Copy for Avalanche

### DIFF
--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -212,7 +212,7 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
         avalanche_train_dataset = to_avalanche_dataset(
-            train_dataset, train_dataset_collate_fn, pickable=False
+            train_dataset, train_dataset_collate_fn, pickable=True
         )
 
         avalanche_state = None

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -211,7 +211,7 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         train_dataset_collate_fn: Optional[Callable] = None,
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
-        train_dataset = to_avalanche_dataset(
+        avalanche_train_dataset = to_avalanche_dataset(
             train_dataset, train_dataset_collate_fn, pickable=False
         )
 
@@ -232,11 +232,11 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
             )
         else:
             val_memory_dataset = to_avalanche_dataset(
-                train_dataset, val_dataset_collate_fn, pickable=True
+                train_dataset, val_dataset_collate_fn, pickable=False
             )
 
         benchmark = AvalancheBenchmarkWrapper(
-            train_dataset=train_dataset,
+            train_dataset=avalanche_train_dataset,
             val_dataset=val_memory_dataset,
             train_transform=self._train_transform,
             train_target_transform=self._train_target_transform,

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -228,11 +228,11 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         if val_dataset is not None:
             self._dummy_learner._val_memory_buffer.update(val_dataset)
             val_memory_dataset = to_avalanche_dataset(
-                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn, pickable=True
+                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn, pickleable=True
             )
         else:
             val_memory_dataset = to_avalanche_dataset(
-                train_dataset, val_dataset_collate_fn, pickable=False
+                train_dataset, val_dataset_collate_fn, pickleable=False
             )
 
         benchmark = AvalancheBenchmarkWrapper(

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -211,7 +211,9 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         train_dataset_collate_fn: Optional[Callable] = None,
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
-        train_dataset = to_avalanche_dataset(train_dataset, train_dataset_collate_fn)
+        train_dataset = to_avalanche_dataset(
+            train_dataset, train_dataset_collate_fn, pickable=False
+        )
 
         avalanche_state = None
         if self._input_state_folder is not None:
@@ -226,10 +228,12 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         if val_dataset is not None:
             self._dummy_learner._val_memory_buffer.update(val_dataset)
             val_memory_dataset = to_avalanche_dataset(
-                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn
+                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn, pickable=True
             )
         else:
-            val_memory_dataset = to_avalanche_dataset(train_dataset, val_dataset_collate_fn)
+            val_memory_dataset = to_avalanche_dataset(
+                train_dataset, val_dataset_collate_fn, pickable=True
+            )
 
         benchmark = AvalancheBenchmarkWrapper(
             train_dataset=train_dataset,

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -211,9 +211,7 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         train_dataset_collate_fn: Optional[Callable] = None,
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
-        avalanche_train_dataset = to_avalanche_dataset(
-            train_dataset, train_dataset_collate_fn, pickleable=False
-        )
+        avalanche_train_dataset = to_avalanche_dataset(train_dataset, train_dataset_collate_fn)
 
         avalanche_state = None
         if self._input_state_folder is not None:
@@ -228,12 +226,10 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         if val_dataset is not None:
             self._dummy_learner._val_memory_buffer.update(val_dataset)
             val_memory_dataset = to_avalanche_dataset(
-                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn, pickleable=True
+                self._dummy_learner._val_memory_buffer, val_dataset_collate_fn
             )
         else:
-            val_memory_dataset = to_avalanche_dataset(
-                train_dataset, val_dataset_collate_fn, pickleable=False
-            )
+            val_memory_dataset = to_avalanche_dataset(train_dataset, val_dataset_collate_fn)
 
         benchmark = AvalancheBenchmarkWrapper(
             train_dataset=avalanche_train_dataset,

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -212,7 +212,7 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
         avalanche_train_dataset = to_avalanche_dataset(
-            train_dataset, train_dataset_collate_fn, pickable=False
+            train_dataset, train_dataset_collate_fn, pickleable=False
         )
 
         avalanche_state = None

--- a/src/renate/updaters/avalanche/model_updater.py
+++ b/src/renate/updaters/avalanche/model_updater.py
@@ -212,7 +212,7 @@ class AvalancheModelUpdater(SingleTrainingLoopUpdater):
         val_dataset_collate_fn: Optional[Callable] = None,
     ) -> AvalancheBenchmarkWrapper:
         avalanche_train_dataset = to_avalanche_dataset(
-            train_dataset, train_dataset_collate_fn, pickable=True
+            train_dataset, train_dataset_collate_fn, pickable=False
         )
 
         avalanche_state = None

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -38,6 +38,9 @@ class AvalancheDataset(Dataset):
             x, _ = self._dataset[idx]
         return x, self._targets[idx]
 
+    def __getstate__(self):
+        return {}
+
 
 def to_avalanche_dataset(
     dataset: Union[Dataset, DataBuffer], collate_fn: Optional[Callable] = None

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -11,10 +11,28 @@ from torch.utils.data import DataLoader, Dataset
 
 from renate.data.datasets import _TransformedDataset
 from renate.memory import DataBuffer
+from renate.types import NestedTensors
 
 
-class AvalancheDataset(Dataset):
-    """A Dataset consumable by Avalanche updaters."""
+class BaseAvalancheDataset(Dataset):
+    """Base class for all datasets consumable by Avalanche updaters."""
+
+    def __init__(
+        self,
+        targets: List[int],
+        collate_fn: Optional[Callable] = None,
+    ):
+        self._targets = targets
+        self.targets = torch.tensor(targets, dtype=torch.long)
+        if collate_fn is not None:
+            self.collate_fn = collate_fn
+
+    def __len__(self) -> int:
+        return len(self._targets)
+
+
+class AvalancheDataset(BaseAvalancheDataset):
+    """A Dataset consumable by Avalanche updaters which cannot be pickled."""
 
     def __init__(
         self,
@@ -22,14 +40,8 @@ class AvalancheDataset(Dataset):
         targets: List[int],
         collate_fn: Optional[Callable] = None,
     ):
+        super().__init__(targets, collate_fn)
         self._dataset = dataset
-        self._targets = targets
-        self.targets = torch.tensor(targets, dtype=torch.long)
-        if collate_fn is not None:
-            self.collate_fn = collate_fn
-
-    def __len__(self) -> int:
-        return len(self._dataset)
 
     def __getitem__(self, idx) -> Tuple[Tensor, int]:
         if isinstance(self._dataset, DataBuffer):
@@ -38,23 +50,39 @@ class AvalancheDataset(Dataset):
             x, _ = self._dataset[idx]
         return x, self._targets[idx]
 
-    def __getstate__(self):
-        return {}
+
+class AvalanchePickableDataset(BaseAvalancheDataset):
+    """A Dataset consumable by Avalanche updaters which can be pickled."""
+
+    def __init__(
+        self, inputs: NestedTensors, targets: List[int], collate_fn: Optional[Callable] = None
+    ):
+        super().__init__(targets, collate_fn)
+        self._inputs = inputs
+
+    def __getitem__(self, idx) -> Tuple[Tensor, int]:
+        return self._inputs[idx], self._targets[idx]
 
 
 def to_avalanche_dataset(
-    dataset: Union[Dataset, DataBuffer], collate_fn: Optional[Callable] = None
+    dataset: Union[Dataset, DataBuffer],
+    collate_fn: Optional[Callable] = None,
+    pickable: bool = False,
 ) -> AvalancheDataset:
     """Converts a DataBuffer or Dataset into an Avalanche-compatible Dataset."""
-    y_data = []
+    x_data, y_data = [], []
     for i in range(len(dataset)):
         if isinstance(dataset, DataBuffer):
-            (_, y), _ = dataset[i]
+            (x, y), _ = dataset[i]
         else:
-            _, y = dataset[i]
+            x, y = dataset[i]
+        if pickable:
+            x_data.append(x)
         if not isinstance(y, int):
             y = y.item()
         y_data.append(y)
+    if pickable:
+        return AvalanchePickableDataset(x_data, y_data, collate_fn)
     return AvalancheDataset(dataset, y_data, collate_fn)
 
 

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -11,43 +11,48 @@ from torch.utils.data import DataLoader, Dataset
 
 from renate.data.datasets import _TransformedDataset
 from renate.memory import DataBuffer
-from renate.types import NestedTensors
 
 
 class AvalancheDataset(Dataset):
     """A Dataset consumable by Avalanche updaters."""
 
     def __init__(
-        self, inputs: NestedTensors, targets: List[int], collate_fn: Optional[Callable] = None
+        self,
+        dataset: Union[Dataset, DataBuffer],
+        targets: List[int],
+        collate_fn: Optional[Callable] = None,
     ):
-        self._inputs = inputs
+        self._dataset = dataset
         self._targets = targets
         self.targets = torch.tensor(targets, dtype=torch.long)
         if collate_fn is not None:
             self.collate_fn = collate_fn
 
     def __len__(self) -> int:
-        return len(self._targets)
+        return len(self._dataset)
 
-    def __getitem__(self, idx) -> Tuple[Tensor, Tensor]:
-        return self._inputs[idx], self._targets[idx]
+    def __getitem__(self, idx) -> Tuple[Tensor, int]:
+        if isinstance(self._dataset, DataBuffer):
+            (x, _), _ = self._dataset[idx]
+        else:
+            x, _ = self._dataset[idx]
+        return x, self._targets[idx]
 
 
 def to_avalanche_dataset(
     dataset: Union[Dataset, DataBuffer], collate_fn: Optional[Callable] = None
 ) -> AvalancheDataset:
     """Converts a DataBuffer or Dataset into an Avalanche-compatible Dataset."""
-    x_data, y_data = [], []
+    y_data = []
     for i in range(len(dataset)):
         if isinstance(dataset, DataBuffer):
-            (x, y), _ = dataset[i]
+            (_, y), _ = dataset[i]
         else:
-            x, y = dataset[i]
-        x_data.append(x)
+            _, y = dataset[i]
         if not isinstance(y, int):
             y = y.item()
         y_data.append(y)
-    return AvalancheDataset(x_data, y_data, collate_fn)
+    return AvalancheDataset(dataset, y_data, collate_fn)
 
 
 class AvalancheBenchmarkWrapper:

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -68,7 +68,7 @@ def to_avalanche_dataset(
     dataset: Union[Dataset, DataBuffer],
     collate_fn: Optional[Callable] = None,
     pickable: bool = False,
-) -> AvalancheDataset:
+) -> BaseAvalancheDataset:
     """Converts a DataBuffer or Dataset into an Avalanche-compatible Dataset."""
     x_data, y_data = [], []
     for i in range(len(dataset)):

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -11,7 +11,6 @@ from torch.utils.data import DataLoader, Dataset
 
 from renate.data.datasets import _TransformedDataset
 from renate.memory import DataBuffer
-from renate.types import NestedTensors
 
 
 class BaseAvalancheDataset(Dataset):
@@ -32,7 +31,7 @@ class BaseAvalancheDataset(Dataset):
 
 
 class AvalancheDataset(BaseAvalancheDataset):
-    """A Dataset consumable by Avalanche updaters which cannot be pickled."""
+    """A wrapper around a Dataset consumable by Avalanche updaters."""
 
     def __init__(
         self,
@@ -44,45 +43,40 @@ class AvalancheDataset(BaseAvalancheDataset):
         self._dataset = dataset
 
     def __getitem__(self, idx) -> Tuple[Tensor, int]:
-        if isinstance(self._dataset, DataBuffer):
-            (x, _), _ = self._dataset[idx]
-        else:
-            x, _ = self._dataset[idx]
-        return x, self._targets[idx]
+        return self._dataset[idx][0], self._targets[idx]
 
 
-class AvalanchePickleableDataset(BaseAvalancheDataset):
-    """A Dataset consumable by Avalanche updaters which can be pickled."""
+class AvalancheDatasetForBuffer(BaseAvalancheDataset):
+    """A wrapper around a DataBuffer consumable by Avalanche updaters."""
 
     def __init__(
-        self, inputs: NestedTensors, targets: List[int], collate_fn: Optional[Callable] = None
+        self, buffer: DataBuffer, targets: List[int], collate_fn: Optional[Callable] = None
     ):
         super().__init__(targets, collate_fn)
-        self._inputs = inputs
+        self._indices = buffer._indices
+        self._datasets = buffer._datasets
 
     def __getitem__(self, idx) -> Tuple[Tensor, int]:
-        return self._inputs[idx], self._targets[idx]
+        i, j = self._indices[idx]
+        return self._datasets[i][j][0], self._targets[idx]
 
 
 def to_avalanche_dataset(
-    dataset: Union[Dataset, DataBuffer],
-    collate_fn: Optional[Callable] = None,
-    pickleable: bool = False,
+    dataset: Union[Dataset, DataBuffer], collate_fn: Optional[Callable] = None
 ) -> BaseAvalancheDataset:
     """Converts a DataBuffer or Dataset into an Avalanche-compatible Dataset."""
-    x_data, y_data = [], []
+    y_data = []
+    is_buffer = isinstance(dataset, DataBuffer)
     for i in range(len(dataset)):
-        if isinstance(dataset, DataBuffer):
-            (x, y), _ = dataset[i]
+        if is_buffer:
+            (_, y), _ = dataset[i]
         else:
-            x, y = dataset[i]
-        if pickleable:
-            x_data.append(x)
+            _, y = dataset[i]
         if not isinstance(y, int):
             y = y.item()
         y_data.append(y)
-    if pickleable:
-        return AvalanchePickleableDataset(x_data, y_data, collate_fn)
+    if is_buffer:
+        return AvalancheDatasetForBuffer(dataset, y_data, collate_fn)
     return AvalancheDataset(dataset, y_data, collate_fn)
 
 

--- a/src/renate/utils/avalanche.py
+++ b/src/renate/utils/avalanche.py
@@ -51,7 +51,7 @@ class AvalancheDataset(BaseAvalancheDataset):
         return x, self._targets[idx]
 
 
-class AvalanchePickableDataset(BaseAvalancheDataset):
+class AvalanchePickleableDataset(BaseAvalancheDataset):
     """A Dataset consumable by Avalanche updaters which can be pickled."""
 
     def __init__(
@@ -67,7 +67,7 @@ class AvalanchePickableDataset(BaseAvalancheDataset):
 def to_avalanche_dataset(
     dataset: Union[Dataset, DataBuffer],
     collate_fn: Optional[Callable] = None,
-    pickable: bool = False,
+    pickleable: bool = False,
 ) -> BaseAvalancheDataset:
     """Converts a DataBuffer or Dataset into an Avalanche-compatible Dataset."""
     x_data, y_data = [], []
@@ -76,13 +76,13 @@ def to_avalanche_dataset(
             (x, y), _ = dataset[i]
         else:
             x, y = dataset[i]
-        if pickable:
+        if pickleable:
             x_data.append(x)
         if not isinstance(y, int):
             y = y.item()
         y_data.append(y)
-    if pickable:
-        return AvalanchePickableDataset(x_data, y_data, collate_fn)
+    if pickleable:
+        return AvalanchePickleableDataset(x_data, y_data, collate_fn)
     return AvalancheDataset(dataset, y_data, collate_fn)
 
 

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -5,6 +5,6 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
-  "expected_accuracy_linux": [[0.7263000011444092, 0.9646999835968018]],
+  "expected_accuracy_linux": [[0.7448999881744385, 0.9642000198364258]],
   "expected_accuracy_darwin": [[0.7087000012397766, 0.9577000141143799]]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -6,5 +6,5 @@
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
   "expected_accuracy_linux": [[0.7448999881744385, 0.9642000198364258]],
-  "expected_accuracy_darwin": [[0.7087000012397766, 0.9577000141143799]]
+  "expected_accuracy_darwin": [[0.7275999784469604, 0.9585000276565552]]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -5,6 +5,6 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
-  "expected_accuracy_linux": [[0.7448999881744385, 0.9642000198364258]],
+  "expected_accuracy_linux": [[0.7448999881744385, 0.9642000198364258], [0.7483000159263611, 0.9634000062942505]],
   "expected_accuracy_darwin": [[0.7275999784469604, 0.9585000276565552]]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -6,5 +6,5 @@
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
   "expected_accuracy_linux": [[0.7263000011444092, 0.9646999835968018]],
-  "expected_accuracy_darwin": [[0.7497000098228455, 0.9664999842643738]]
+  "expected_accuracy_darwin": [[0.7087000012397766, 0.9577000141143799]]
 }

--- a/test/integration_tests/configs/suites/quick/avalanche-ewc.json
+++ b/test/integration_tests/configs/suites/quick/avalanche-ewc.json
@@ -5,6 +5,6 @@
   "dataset": "mnist.json",
   "backend": "local",
   "job_name": "rotation-mlp-avalanche-ewc",
-  "expected_accuracy_linux": [[0.7580999732017517, 0.9627000093460083], [0.7551000118255615, 0.9664999842643738]],
+  "expected_accuracy_linux": [[0.7263000011444092, 0.9646999835968018]],
   "expected_accuracy_darwin": [[0.7497000098228455, 0.9664999842643738]]
 }

--- a/test/renate/utils/test_avalanche.py
+++ b/test/renate/utils/test_avalanche.py
@@ -8,6 +8,7 @@ from avalanche.training.plugins import EWCPlugin, ReplayPlugin
 from torch import Tensor
 from torch.utils.data import Subset, TensorDataset
 
+from renate.memory import ReservoirBuffer
 from renate.utils.avalanche import (
     AvalancheBenchmarkWrapper,
     _plugin_index,
@@ -18,26 +19,30 @@ from renate.utils.avalanche import (
 )
 
 
-@pytest.mark.parametrize("pickleable", [True, False])
-def test_to_avalanche_dataset(pickleable):
+@pytest.mark.parametrize("use_buffer", [True, False])
+def test_to_avalanche_dataset(use_buffer):
     expected_x = 6
     expected_y = 1
     tensor_dataset = TensorDataset(
         torch.tensor([5, expected_x, 7]), torch.tensor([0, expected_y, 2])
     )
-    dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]), pickleable=pickleable)
+    if use_buffer:
+        buffer = ReservoirBuffer(10)
+        buffer.update(tensor_dataset)
+        dataset = to_avalanche_dataset(buffer)
+    else:
+        dataset = to_avalanche_dataset(Subset(tensor_dataset, [0, 1, 2]))
     assert type(dataset._targets) == list
-    assert len(dataset._targets) == 1
-    assert dataset._targets[0] == expected_y
+    assert len(dataset._targets) == 3
+    assert dataset._targets[1] == expected_y
     assert type(dataset._targets[0]) == int
-    assert dataset.targets.item() == dataset._targets[0]
-    assert dataset.targets == expected_y
+    assert dataset.targets[0].item() == dataset._targets[0]
+    assert dataset.targets[1] == expected_y
     assert type(dataset.targets) == Tensor
-    x, y = dataset[0]
+    x, y = dataset[1]
     assert x == expected_x and y == expected_y
-    assert len(dataset) == 1
-    if pickleable:
-        pickle.dumps(dataset)
+    assert len(dataset) == 3
+    pickle.dumps(dataset)
 
 
 def test_avalanche_benchmark_wrapper_correctly_tracks_and_saves_state():

--- a/test/renate/utils/test_avalanche.py
+++ b/test/renate/utils/test_avalanche.py
@@ -18,14 +18,14 @@ from renate.utils.avalanche import (
 )
 
 
-@pytest.mark.parametrize("pickable", [True, False])
-def test_to_avalanche_dataset(pickable):
+@pytest.mark.parametrize("pickleable", [True, False])
+def test_to_avalanche_dataset(pickleable):
     expected_x = 6
     expected_y = 1
     tensor_dataset = TensorDataset(
         torch.tensor([5, expected_x, 7]), torch.tensor([0, expected_y, 2])
     )
-    dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]), pickable=pickable)
+    dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]), pickleable=pickleable)
     assert type(dataset._targets) == list
     assert len(dataset._targets) == 1
     assert dataset._targets[0] == expected_y
@@ -36,7 +36,7 @@ def test_to_avalanche_dataset(pickable):
     x, y = dataset[0]
     assert x == expected_x and y == expected_y
     assert len(dataset) == 1
-    if pickable:
+    if pickleable:
         pickle.dumps(dataset)
 
 

--- a/test/renate/utils/test_avalanche.py
+++ b/test/renate/utils/test_avalanche.py
@@ -23,7 +23,6 @@ def test_to_avalanche_dataset():
         torch.tensor([5, expected_x, 7]), torch.tensor([0, expected_y, 2])
     )
     dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]))
-    assert dataset._inputs[0].item() == expected_x
     assert type(dataset._targets) == list
     assert len(dataset._targets) == 1
     assert dataset._targets[0] == expected_y

--- a/test/renate/utils/test_avalanche.py
+++ b/test/renate/utils/test_avalanche.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import pickle
+
 import pytest
 import torch
 from avalanche.training.plugins import EWCPlugin, ReplayPlugin
@@ -16,13 +18,14 @@ from renate.utils.avalanche import (
 )
 
 
-def test_to_avalanche_dataset():
+@pytest.mark.parametrize("pickable", [True, False])
+def test_to_avalanche_dataset(pickable):
     expected_x = 6
     expected_y = 1
     tensor_dataset = TensorDataset(
         torch.tensor([5, expected_x, 7]), torch.tensor([0, expected_y, 2])
     )
-    dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]))
+    dataset = to_avalanche_dataset(Subset(tensor_dataset, [1]), pickable=pickable)
     assert type(dataset._targets) == list
     assert len(dataset._targets) == 1
     assert dataset._targets[0] == expected_y
@@ -33,6 +36,8 @@ def test_to_avalanche_dataset():
     x, y = dataset[0]
     assert x == expected_x and y == expected_y
     assert len(dataset) == 1
+    if pickable:
+        pickle.dumps(dataset)
 
 
 def test_avalanche_benchmark_wrapper_correctly_tracks_and_saves_state():


### PR DESCRIPTION
To make a dataset avalanche-compatible, a special avalanche dataset was introduced. However, as part of the creation, an in-memory copy was created which causes problems with larger datasets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
